### PR TITLE
Explicit messages in case of 4XX failures

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -64,6 +64,15 @@ class Api(private val nodeParams: NodeParams, private val peer: Peer, private va
             exception<Throwable> { call, cause ->
                 call.respondText(text = cause.message ?: "", status = defaultExceptionStatusCode(cause) ?: HttpStatusCode.InternalServerError)
             }
+            status(HttpStatusCode.Unauthorized) { call, status ->
+                call.respondText(text = "Invalid authentication (use basic auth with the http password set in phoenix.conf)", status = status)
+            }
+            status(HttpStatusCode.MethodNotAllowed) { call, status ->
+                call.respondText(text = "Invalid http method (use the correct GET/POST)", status = status)
+            }
+            status(HttpStatusCode.NotFound) { call, status ->
+                call.respondText(text = "Unknown endpoint (check api doc)", status = status)
+            }
         }
         install(Authentication) {
             basic {


### PR DESCRIPTION
```
$ curl -u :bad-password http://127.0.0.1:9740/getinfo
Invalid authentication (use basic auth with the http password set in phoenix.conf)

$ curl -u :4034..8232 http://127.0.0.1:9740/getinfowithtypo
Unknown endpoint (check api doc)

$ curl -u :4034..8232 -X POST http://127.0.0.1:9740/getinfowithtypo
Invalid http method (use the correct GET/POST)
```

Fixes #4 