### PR TITLE
meta: add nix shell to build on Linux

### DIFF
--- a/.nix/shell.nix
+++ b/.nix/shell.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.sqlite
+    pkgs.curl
+    pkgs.openjdk17
+
+    (pkgs.glibc.overrideAttrs (old: {
+      version = "2.19";
+    }))
+  ];
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Requires `libsqlite-dev` and `libcurl4-gnutls-dev`, both compiled against `glibc
 ./gradlew packageLinuxX64
 ```
 
+If you are on a system with a different glibc, try to use nix and build phoenixd inside the shell that you can create with the command `nix-shell .nix/shell.nix`.
+
 ### Native MacOS x64
 ```shell
 ./gradlew packageMacOSX64


### PR DESCRIPTION
As noted in [1] on Linux systems, it is not possible to build phoenixd due to a mismatch in the libc version.

A possible solution is to use Nix and build phoenixd inside the shell with all the dependencies. This way, the host machine can use the binary directly without downgrading libc, which can be dangerous.

[1] https://github.com/ACINQ/phoenixd/issues/1#issuecomment-2018205685

Adding this as a draft due that I am finishing building it on my machine for testing