### PR TITLE
Do not add linux target on aarch64 architectures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,7 +88,11 @@ kotlin {
     }
 
     val currentOs = org.gradle.internal.os.OperatingSystem.current()
-    if (currentOs.isLinux) {
+    val arch = System.getProperty("os.arch")
+
+    if (currentOs.isLinux && arch != "aarch64") {
+        // there is no kotlin native toolchain for linux arm64 yet, but we can still build for the JVM
+        // see https://youtrack.jetbrains.com/issue/KT-51794/Cant-run-JVM-targets-on-ARM-Linux-when-using-Kotlin-Multiplatform-plugin
         linuxX64 {
             phoenixBinaries()
         }


### PR DESCRIPTION
It would fail as there is no kotlin-native toolchain yet and prevent us from building JVM targets. This would fix the docker build issue on linux arm64 (see https://github.com/ACINQ/phoenixd/pull/17).