### PR TITLE
Replace `--max-absolute-fee` by `--max-mining-fee`

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     val kotlin = "1.9.23"
-    val lightningKmp = "1.6.2-FEECREDIT-5"
+    val lightningKmp = "1.6.2-FEECREDIT-6"
     val sqlDelight = "2.0.1"
     val okio = "3.8.0"
     val clikt = "4.2.2"

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
@@ -124,7 +124,9 @@ class Phoenixd : CliktCommand() {
         val maxMiningFee by option("--max-mining-fee", help = "Max mining fee for on-chain operations, in satoshis")
             .int().convert { it.sat }
             .restrictTo(5_000.sat..200_000.sat)
-            .default(40_000.sat)
+            .defaultLazy("1% of auto-liquidity amount") {
+                autoLiquidity * 1 / 100
+            }
         val maxFeeCredit by option("--max-fee-credit", help = "Max fee credit, if reached payments will be rejected").choice(
             "off" to 0.sat,
             "50k" to 50_000.sat,


### PR DESCRIPTION
It makes much more sense to consider only the mining fee, for the absolute fee check, as it is volatile and amount-independent. The service fee is in % and predictable.

The default value is equivalent as before (1% of the default `auto-liquidity`, given that the previous value of 2% included the 1% liquidity service fee). Previous option is deprecated and explicitly rejected.