### PR TITLE
Add endpoints to list incoming and outgoing payments

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/db/payments/IncomingQueries.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/db/payments/IncomingQueries.kt
@@ -21,6 +21,7 @@ import app.cash.sqldelight.coroutines.mapToList
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.byteVector32
 import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.utils.currentTimestampMillis
 import fr.acinq.phoenix.db.PhoenixDatabase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -130,9 +131,14 @@ class IncomingQueries(private val database: PhoenixDatabase) {
         return queries.listAllNotConfirmed(Companion::mapIncomingPayment).asFlow().mapToList(Dispatchers.IO)
     }
 
+    fun listReceivedPayments(from: Long, to: Long, limit: Long, offset: Long): List<IncomingPayment> {
+        return queries.listReceivedWithin(from = from, to = to, limit, offset, ::mapIncomingPayment).executeAsList()
+    }
+
     fun listExpiredPayments(fromCreatedAt: Long, toCreatedAt: Long): List<IncomingPayment> {
-        return queries.listAllWithin(fromCreatedAt, toCreatedAt, Companion::mapIncomingPayment).executeAsList().filter {
-            it.received == null
+        return queries.listCreatedWithin(fromCreatedAt, toCreatedAt, Companion::mapIncomingPayment).executeAsList().filter {
+            val origin = it.origin
+            it.received == null && origin is IncomingPayment.Origin.Invoice && origin.paymentRequest.isExpired()
         }
     }
 
@@ -185,13 +191,6 @@ class IncomingQueries(private val database: PhoenixDatabase) {
                 }
                 else -> throw UnreadableIncomingReceivedWith(received_at, received_with_type, received_with_blob)
             }
-        }
-
-        private fun mapTxIdPaymentHash(
-            tx_id: ByteArray,
-            payment_hash: ByteArray
-        ): Pair<ByteVector32, ByteVector32> {
-            return tx_id.byteVector32() to payment_hash.byteVector32()
         }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/db/payments/LightningOutgoingQueries.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/db/payments/LightningOutgoingQueries.kt
@@ -158,7 +158,17 @@ class LightningOutgoingQueries(val database: PhoenixDatabase) {
         }
     }
 
-    fun listLightningOutgoingPayments(paymentHash: ByteVector32): List<LightningOutgoingPayment> {
+    fun listPayments(from: Long, to: Long, limit: Long, offset: Long): List<LightningOutgoingPayment> {
+        return queries.listPaymentsWithin(from, to, limit, offset, Companion::mapLightningOutgoingPayment).executeAsList()
+            .let { groupByRawLightningOutgoing(it) }
+    }
+
+    fun listPaymentsSent(from: Long, to: Long, limit: Long, offset: Long): List<LightningOutgoingPayment> {
+        return queries.listPaymentsSentWithin(from, to, limit, offset, Companion::mapLightningOutgoingPayment).executeAsList()
+            .let { groupByRawLightningOutgoing(it) }
+    }
+
+    fun listPaymentsForPaymentHash(paymentHash: ByteVector32): List<LightningOutgoingPayment> {
         return queries.listPaymentsForPaymentHash(paymentHash.toByteArray(), Companion::mapLightningOutgoingPayment).executeAsList()
             .let { groupByRawLightningOutgoing(it) }
     }
@@ -183,7 +193,7 @@ class LightningOutgoingQueries(val database: PhoenixDatabase) {
 
     companion object {
         @Suppress("UNUSED_PARAMETER")
-        fun mapLightningOutgoingPaymentWithoutParts(
+        private fun mapLightningOutgoingPaymentWithoutParts(
             id: String,
             recipient_amount_msat: Long,
             recipient_node_id: String,
@@ -207,7 +217,6 @@ class LightningOutgoingQueries(val database: PhoenixDatabase) {
             )
         }
 
-        @Suppress("UNUSED_PARAMETER")
         fun mapLightningOutgoingPayment(
             id: String,
             recipient_amount_msat: Long,

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/db/payments/LightningOutgoingQueries.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/db/payments/LightningOutgoingQueries.kt
@@ -163,8 +163,8 @@ class LightningOutgoingQueries(val database: PhoenixDatabase) {
             .let { groupByRawLightningOutgoing(it) }
     }
 
-    fun listPaymentsSent(from: Long, to: Long, limit: Long, offset: Long): List<LightningOutgoingPayment> {
-        return queries.listPaymentsSentWithin(from, to, limit, offset, Companion::mapLightningOutgoingPayment).executeAsList()
+    fun listSuccessfulOrPendingPayments(from: Long, to: Long, limit: Long, offset: Long): List<LightningOutgoingPayment> {
+        return queries.listSuccessfulOrPendingPaymentsWithin(from, to, limit, offset, Companion::mapLightningOutgoingPayment).executeAsList()
             .let { groupByRawLightningOutgoing(it) }
     }
 

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
@@ -22,7 +22,7 @@ import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.bin.db.PaymentMetadata
 import fr.acinq.lightning.channel.states.ChannelState
 import fr.acinq.lightning.channel.states.ChannelStateWithCommitments
-import fr.acinq.lightning.db.LightningOutgoingPayment
+import fr.acinq.lightning.db.*
 import fr.acinq.lightning.json.JsonSerializers
 import fr.acinq.lightning.utils.UUID
 import kotlinx.datetime.Clock
@@ -118,8 +118,9 @@ sealed class ApiType {
 
     @Serializable
     @SerialName("outgoing_payment")
-    data class OutgoingPayment(val paymentHash: ByteVector32, val preimage: ByteVector32?, val isPaid: Boolean, val sent: Satoshi, val fees: MilliSatoshi, val invoice: String?, val completedAt: Long?, val createdAt: Long) {
-        constructor(payment: LightningOutgoingPayment) : this (
+    data class OutgoingPayment(val paymentId: String, val paymentHash: ByteVector32, val preimage: ByteVector32?, val isPaid: Boolean, val sent: Satoshi, val fees: MilliSatoshi, val invoice: String?, val completedAt: Long?, val createdAt: Long) {
+        constructor(payment: LightningOutgoingPayment) : this(
+            paymentId = payment.id.toString(),
             paymentHash = payment.paymentHash,
             preimage = (payment.status as? LightningOutgoingPayment.Status.Completed.Succeeded.OffChain)?.preimage,
             invoice = (payment.details as? LightningOutgoingPayment.Details.Normal)?.paymentRequest?.write(),

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
@@ -124,7 +124,7 @@ sealed class ApiType {
             paymentHash = payment.paymentHash,
             preimage = (payment.status as? LightningOutgoingPayment.Status.Completed.Succeeded.OffChain)?.preimage,
             invoice = (payment.details as? LightningOutgoingPayment.Details.Normal)?.paymentRequest?.write(),
-            isPaid = payment.completedAt != null,
+            isPaid = payment.status is LightningOutgoingPayment.Status.Completed.Succeeded.OffChain,
             sent = payment.amount.truncateToSatoshi(),
             fees = payment.fees,
             completedAt = payment.completedAt,

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
@@ -102,10 +102,10 @@ sealed class ApiType {
     @Serializable
     @SerialName("incoming_payment")
     data class IncomingPayment(val paymentHash: ByteVector32, val preimage: ByteVector32, val externalId: String?, val description: String?, val invoice: String?, val isPaid: Boolean, val receivedSat: Satoshi, val fees: MilliSatoshi, val completedAt: Long?, val createdAt: Long) {
-        constructor(payment: fr.acinq.lightning.db.IncomingPayment, metadata: PaymentMetadata?) : this (
+        constructor(payment: fr.acinq.lightning.db.IncomingPayment, externalId: String?) : this (
             paymentHash = payment.paymentHash,
             preimage = payment.preimage,
-            externalId = metadata?.externalId,
+            externalId = externalId,
             description = (payment.origin as? fr.acinq.lightning.db.IncomingPayment.Origin.Invoice)?.paymentRequest?.description,
             invoice = (payment.origin as? fr.acinq.lightning.db.IncomingPayment.Origin.Invoice)?.paymentRequest?.write(),
             isPaid = payment.completedAt != null,

--- a/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
@@ -127,8 +127,8 @@ class GetOutgoingPayment : PhoenixCliCommand(name = "getoutgoingpayment", help =
 }
 
 class ListOutgoingPayments : PhoenixCliCommand(name = "listoutgoingpayments", help = "List outgoing payments") {
-    private val from by option("--from").long().help { "timestamp in millis since epoch" }
-    private val to by option("--to").long().help { "timestamp in millis since epoch" }
+    private val from by option("--from").long().help { "start timestamp in millis since epoch" }
+    private val to by option("--to").long().help { "end timestamp in millis since epoch" }
     private val limit by option("--limit").long().default(20).help { "number of payments in the page" }
     private val offset by option("--offset").long().default(0).help { "page offset" }
     private val all by option("--all").boolean().default(false).help { "if true, include failed payments" }
@@ -153,8 +153,8 @@ class GetIncomingPayment : PhoenixCliCommand(name = "getincomingpayment", help =
 }
 
 class ListIncomingPayments : PhoenixCliCommand(name = "listincomingpayments", help = "List incoming payments") {
-    private val from by option("--from").long().help { "timestamp in millis since epoch" }
-    private val to by option("--to").long().help { "timestamp in millis since epoch" }
+    private val from by option("--from").long().help { "start timestamp in millis since epoch" }
+    private val to by option("--to").long().help { "end timestamp in millis since epoch" }
     private val limit by option("--limit").long().default(20).help { "number of payments in the page" }
     private val offset by option("--offset").long().default(0).help { "page offset" }
     private val all by option("--all").boolean().default(false).help { "if true, include unpaid invoices" }

--- a/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
@@ -138,8 +138,8 @@ class ListOutgoingPayments : PhoenixCliCommand(name = "listoutgoingpayments", he
                 parameters.append("all", all.toString())
                 from?.let { parameters.append("from", it.toString()) }
                 to?.let { parameters.append("to", it.toString()) }
-                limit?.let { parameters.append("limit", it.toString()) }
-                offset?.let { parameters.append("offset", it.toString()) }
+                parameters.append("limit", limit.toString())
+                parameters.append("offset", offset.toString())
             }
         }
     }
@@ -166,8 +166,8 @@ class ListIncomingPayments : PhoenixCliCommand(name = "listincomingpayments", he
                 externalId?.let { parameters.append("externalId", it) }
                 from?.let { parameters.append("from", it.toString()) }
                 to?.let { parameters.append("to", it.toString()) }
-                limit?.let { parameters.append("limit", it.toString()) }
-                offset?.let { parameters.append("offset", it.toString()) }
+                parameters.append("limit", limit.toString())
+                parameters.append("offset", offset.toString())
             }
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
@@ -126,12 +126,12 @@ class GetOutgoingPayment : PhoenixCliCommand(name = "getoutgoingpayment", help =
     }
 }
 
-class ListOutgoingPayments : PhoenixCliCommand(name = "listoutgoingpayments", help = "List outgoing payments matching the given parameters. By default, return the last pending or successfully sent payments.") {
-    private val all by option("--all").boolean().default(false).help { "if true, list all outgoing payments, including failed ones" }
+class ListOutgoingPayments : PhoenixCliCommand(name = "listoutgoingpayments", help = "List outgoing payments") {
     private val from by option("--from").long().help { "timestamp in millis since epoch" }
     private val to by option("--to").long().help { "timestamp in millis since epoch" }
-    private val limit by option("--limit", "-l").long().help { "number of payments in the page, default 20" }
-    private val offset by option("--offset", "-o").long().help { "page offset, default 0 (i.e. the first page)" }
+    private val limit by option("--limit").long().default(20).help { "number of payments in the page" }
+    private val offset by option("--offset").long().default(0).help { "page offset" }
+    private val all by option("--all").boolean().default(false).help { "if true, include failed payments" }
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.get(url = commonOptions.baseUrl / "payments/outgoing") {
             url {
@@ -152,13 +152,13 @@ class GetIncomingPayment : PhoenixCliCommand(name = "getincomingpayment", help =
     }
 }
 
-class ListIncomingPayments : PhoenixCliCommand(name = "listincomingpayments", help = "List incoming payments matching the given parameters. By default, return the last received payments.") {
-    private val all by option("--all").boolean().default(false).help { "if true, list all incoming payments, including those that have not been received" }
-    private val externalId by option("--externalId", "--eid").help { "optional external id tied to the payments" }
+class ListIncomingPayments : PhoenixCliCommand(name = "listincomingpayments", help = "List incoming payments") {
     private val from by option("--from").long().help { "timestamp in millis since epoch" }
     private val to by option("--to").long().help { "timestamp in millis since epoch" }
-    private val limit by option("--limit", "-l").long().help { "number of payments in the page, default 20" }
-    private val offset by option("--offset", "-o").long().help { "page offset, default 0 (i.e. the first page)" }
+    private val limit by option("--limit").long().default(20).help { "number of payments in the page" }
+    private val offset by option("--offset").long().default(0).help { "page offset" }
+    private val all by option("--all").boolean().default(false).help { "if true, include unpaid invoices" }
+    private val externalId by option("--externalId").help { "optional external id tied to the payments" }
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.get(url = commonOptions.baseUrl / "payments/incoming") {
             url {

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
@@ -65,7 +65,14 @@ WHERE    received_at IS NOT NULL
 ORDER BY r.received_at ASC
 LIMIT 1;
 
-listAllWithin:
+listReceivedWithin:
+SELECT payment_hash, preimage, created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob
+FROM   incoming_payments
+WHERE  received_at IS NOT NULL AND received_at BETWEEN :from AND :to
+ORDER BY received_at DESC
+LIMIT :limit OFFSET :offset;
+
+listCreatedWithin:
 SELECT payment_hash, preimage, created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob
 FROM   incoming_payments
 WHERE  created_at BETWEEN :from AND :to

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
@@ -66,13 +66,47 @@ ORDER BY r.received_at ASC
 LIMIT 1;
 
 listReceivedWithin:
-SELECT payment_hash, preimage, created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob
-FROM   incoming_payments
+SELECT payment_hash, preimage, payment.created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob, meta.external_id
+FROM   incoming_payments AS payment
+LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = payment.payment_hash
 WHERE  received_at IS NOT NULL AND received_at BETWEEN :from AND :to
-ORDER BY received_at DESC
+ORDER BY
+        coalesce(received_at, payment.created_at) DESC,
+        payment_hash DESC
+LIMIT :limit OFFSET :offset;
+
+listReceivedForExternalIdWithin:
+SELECT payment_hash, preimage, payment.created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob, meta.external_id
+FROM   incoming_payments AS payment
+LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = payment.payment_hash
+WHERE  meta.external_id = :externalId AND received_at IS NOT NULL AND received_at BETWEEN :from AND :to
+ORDER BY
+        coalesce(received_at, payment.created_at) DESC,
+        payment_hash DESC
 LIMIT :limit OFFSET :offset;
 
 listCreatedWithin:
+SELECT payment_hash, preimage, payment.created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob, meta.external_id
+FROM   incoming_payments AS payment
+LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = payment.payment_hash
+WHERE  payment.created_at BETWEEN :from AND :to
+ORDER BY
+       coalesce(received_at, payment.created_at) DESC,
+       payment_hash DESC
+LIMIT :limit OFFSET :offset;
+
+listCreatedForExternalIdWithin:
+SELECT payment_hash, preimage, payment.created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob, meta.external_id
+FROM   incoming_payments AS payment
+LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = payment.payment_hash
+WHERE  meta.external_id = :externalId
+AND    payment.created_at BETWEEN :from AND :to
+ORDER BY
+       coalesce(received_at, payment.created_at) DESC,
+       payment_hash DESC
+LIMIT :limit OFFSET :offset;
+
+listCreatedWithinNoPaging:
 SELECT payment_hash, preimage, created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob
 FROM   incoming_payments
 WHERE  created_at BETWEEN :from AND :to
@@ -87,8 +121,7 @@ LEFT OUTER JOIN link_tx_to_payments
     ON link_tx_to_payments.type = 1
     AND link_tx_to_payments.confirmed_at IS NULL
     AND link_tx_to_payments.id = incoming_payments.payment_hash
-WHERE received_at IS NOT NULL
-;
+WHERE received_at IS NOT NULL;
 
 scanCompleted:
 SELECT payment_hash,

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
@@ -68,7 +68,7 @@ LIMIT 1;
 listReceivedWithin:
 SELECT payment_hash, preimage, payment.created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob, meta.external_id
 FROM   incoming_payments AS payment
-LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = payment.payment_hash
+LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = lower(hex(payment.payment_hash))
 WHERE  received_at IS NOT NULL AND received_at BETWEEN :from AND :to
 ORDER BY
         coalesce(received_at, payment.created_at) DESC,
@@ -78,7 +78,7 @@ LIMIT :limit OFFSET :offset;
 listReceivedForExternalIdWithin:
 SELECT payment_hash, preimage, payment.created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob, meta.external_id
 FROM   incoming_payments AS payment
-LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = payment.payment_hash
+LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = lower(hex(payment.payment_hash))
 WHERE  meta.external_id = :externalId AND received_at IS NOT NULL AND received_at BETWEEN :from AND :to
 ORDER BY
         coalesce(received_at, payment.created_at) DESC,
@@ -88,7 +88,7 @@ LIMIT :limit OFFSET :offset;
 listCreatedWithin:
 SELECT payment_hash, preimage, payment.created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob, meta.external_id
 FROM   incoming_payments AS payment
-LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = payment.payment_hash
+LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = lower(hex(payment.payment_hash))
 WHERE  payment.created_at BETWEEN :from AND :to
 ORDER BY
        coalesce(received_at, payment.created_at) DESC,
@@ -98,7 +98,7 @@ LIMIT :limit OFFSET :offset;
 listCreatedForExternalIdWithin:
 SELECT payment_hash, preimage, payment.created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob, meta.external_id
 FROM   incoming_payments AS payment
-LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = payment.payment_hash
+LEFT OUTER JOIN payments_metadata AS meta ON meta.type = 1 AND meta.id = lower(hex(payment.payment_hash))
 WHERE  meta.external_id = :externalId
 AND    payment.created_at BETWEEN :from AND :to
 ORDER BY

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LightningOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LightningOutgoingPayments.sq
@@ -175,6 +175,57 @@ FROM lightning_outgoing_payments AS parent
 LEFT OUTER JOIN lightning_outgoing_payment_parts AS lightning_parts ON lightning_parts.part_parent_id = parent.id
 WHERE payment_hash=?;
 
+listPaymentsWithin:
+SELECT parent.id,
+       parent.recipient_amount_msat,
+       parent.recipient_node_id,
+       parent.payment_hash,
+       parent.details_type,
+       parent.details_blob,
+       parent.created_at,
+       parent.completed_at,
+       parent.status_type,
+       parent.status_blob,
+       -- lightning parts
+       lightning_parts.part_id AS lightning_part_id,
+       lightning_parts.part_amount_msat AS lightning_part_amount_msat,
+       lightning_parts.part_route AS lightning_part_route,
+       lightning_parts.part_created_at AS lightning_part_created_at,
+       lightning_parts.part_completed_at AS lightning_part_completed_at,
+       lightning_parts.part_status_type AS lightning_part_status_type,
+       lightning_parts.part_status_blob AS lightning_part_status_blob
+FROM lightning_outgoing_payments AS parent
+LEFT OUTER JOIN lightning_outgoing_payment_parts AS lightning_parts ON lightning_parts.part_parent_id = parent.id
+WHERE created_at BETWEEN :startDate AND :endDate
+ORDER BY coalesce(parent.completed_at, parent.created_at) DESC
+LIMIT :limit OFFSET :offset;
+
+listPaymentsSentWithin:
+SELECT parent.id,
+       parent.recipient_amount_msat,
+       parent.recipient_node_id,
+       parent.payment_hash,
+       parent.details_type,
+       parent.details_blob,
+       parent.created_at,
+       parent.completed_at,
+       parent.status_type,
+       parent.status_blob,
+       -- lightning parts
+       lightning_parts.part_id AS lightning_part_id,
+       lightning_parts.part_amount_msat AS lightning_part_amount_msat,
+       lightning_parts.part_route AS lightning_part_route,
+       lightning_parts.part_created_at AS lightning_part_created_at,
+       lightning_parts.part_completed_at AS lightning_part_completed_at,
+       lightning_parts.part_status_type AS lightning_part_status_type,
+       lightning_parts.part_status_blob AS lightning_part_status_blob
+FROM lightning_outgoing_payments AS parent
+LEFT OUTER JOIN lightning_outgoing_payment_parts AS lightning_parts ON lightning_parts.part_parent_id = parent.id
+WHERE completed_at IS NOT NULL
+AND   created_at BETWEEN :startDate AND :endDate
+ORDER BY coalesce(parent.completed_at, parent.created_at) DESC
+LIMIT :limit OFFSET :offset;
+
 -- use this in a `transaction` block to know how many rows were changed after an UPDATE
 changes:
 SELECT changes();

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LightningOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LightningOutgoingPayments.sq
@@ -200,7 +200,7 @@ WHERE created_at BETWEEN :startDate AND :endDate
 ORDER BY coalesce(parent.completed_at, parent.created_at) DESC
 LIMIT :limit OFFSET :offset;
 
-listPaymentsSentWithin:
+listSuccessfulOrPendingPaymentsWithin:
 SELECT parent.id,
        parent.recipient_amount_msat,
        parent.recipient_node_id,
@@ -221,7 +221,7 @@ SELECT parent.id,
        lightning_parts.part_status_blob AS lightning_part_status_blob
 FROM lightning_outgoing_payments AS parent
 LEFT OUTER JOIN lightning_outgoing_payment_parts AS lightning_parts ON lightning_parts.part_parent_id = parent.id
-WHERE completed_at IS NOT NULL
+WHERE ((completed_at IS NOT NULL AND status_type = 'SUCCEEDED_OFFCHAIN_V0') OR completed_at IS NULL)
 AND   created_at BETWEEN :startDate AND :endDate
 ORDER BY coalesce(parent.completed_at, parent.created_at) DESC
 LIMIT :limit OFFSET :offset;


### PR DESCRIPTION
This PR adds one API endpoint (`GET /payments/outgoing`) that returns a list of outgoing payments. Timestamps can be provided to filter the list on creation/completion date, as well as paging parameters. By default, only payments that have been successfully sent or are still pending are returned, but there's an optional parameter to get all payments regardless of status.

The existing `GET /payments/incoming` has been updated to accept the same timestamps and paging parameters as the new outgoing payments endpoint. Similarly, this command will by default only return payments that have been successfully received.