### PR TITLE
Add support for bip353 dns address

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     val kotlin = "1.9.23"
-    val lightningKmp = "1.7.0-FEECREDIT-8"
+    val lightningKmp = "1.7.1-FEECREDIT-9"
     val sqlDelight = "2.0.1"
     val okio = "3.8.0"
     val clikt = "4.2.2"

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -140,6 +140,9 @@ class Api(private val nodeParams: NodeParams, private val peer: Peer, private va
                 get("getoffer") {
                     call.respond(nodeParams.defaultOffer(peer.walletParams.trampolineNode.id).first.encode())
                 }
+                get("getaddress") {
+                    call.respond(if (peer.channels.isNotEmpty()) peer.requestAddress("en") else "must have one channel")
+                }
                 get("payments/incoming") {
                     val listAll = call.parameters["all"]?.toBoolean() ?: false // by default, only list incoming payments that have been received
                     val externalId = call.parameters["externalId"] // may filter incoming payments by an external id

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -8,13 +8,14 @@ import fr.acinq.bitcoin.utils.Either
 import fr.acinq.bitcoin.utils.toEither
 import fr.acinq.lightning.BuildVersions
 import fr.acinq.lightning.Lightning.randomBytes32
-import fr.acinq.lightning.Lightning.randomKey
 import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.bin.db.SqlitePaymentsDb
 import fr.acinq.lightning.bin.db.WalletPaymentId
 import fr.acinq.lightning.bin.json.ApiType.*
 import fr.acinq.lightning.bin.json.ApiType.IncomingPayment
 import fr.acinq.lightning.bin.json.ApiType.OutgoingPayment
+import fr.acinq.lightning.bin.payments.Parser
+import fr.acinq.lightning.bin.payments.PayDnsAddress
 import fr.acinq.lightning.blockchain.fee.FeeratePerByte
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.ChannelCommand
@@ -54,6 +55,8 @@ class Api(private val nodeParams: NodeParams, private val peer: Peer, private va
 
     @OptIn(ExperimentalSerializationApi::class)
     fun Application.module() {
+
+        val payDnsAddress = PayDnsAddress()
 
         val json = Json {
             prettyPrint = true
@@ -207,6 +210,24 @@ class Api(private val nodeParams: NodeParams, private val peer: Peer, private va
                         is fr.acinq.lightning.io.OfferNotPaid -> call.respond(PaymentFailed(event))
                     }
                 }
+                post("paydnsaddress") {
+                    val formParameters = call.receiveParameters()
+                    val overrideAmount = formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
+                    val (username, domain) = formParameters.getEmailLikeAddress("address")
+                    val offer = payDnsAddress.resolveBip353Offer(username, domain)
+                    when (offer) {
+                        null -> call.respond("no valid offer found for that address")
+                        else -> {
+                            val amount = (overrideAmount ?: offer.amount) ?: missing("amountSat")
+                            val note = formParameters["message"]
+                            when (val event = peer.payOffer(amount, offer, payerKey = nodeParams.defaultOffer(peer.walletParams.trampolineNode.id).second, payerNote = note, fetchInvoiceTimeout = 30.seconds)) {
+                                is fr.acinq.lightning.io.PaymentSent -> call.respond(PaymentSent(event))
+                                is fr.acinq.lightning.io.PaymentNotSent -> call.respond(PaymentFailed(event))
+                                is fr.acinq.lightning.io.OfferNotPaid -> call.respond(PaymentFailed(event))
+                            }
+                        }
+                    }
+                }
                 post("decodeinvoice") {
                     val formParameters = call.receiveParameters()
                     val invoice = formParameters.getInvoice("invoice")
@@ -307,5 +328,7 @@ class Api(private val nodeParams: NodeParams, private val peer: Peer, private va
     private fun Parameters.getLong(argName: String): Long = ((this[argName] ?: missing(argName)).toLongOrNull()) ?: invalidType(argName, "integer")
 
     private fun Parameters.getOptionalLong(argName: String): Long? = this[argName]?.let { it.toLongOrNull() ?: invalidType(argName, "integer") }
+
+    private fun Parameters.getEmailLikeAddress(argName: String): Pair<String, String> = this[argName]?.let { Parser.parseEmailLikeAddress(it) } ?: invalidType(argName, "username@domain")
 
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -143,7 +143,7 @@ class Api(private val nodeParams: NodeParams, private val peer: Peer, private va
                 get("getoffer") {
                     call.respond(nodeParams.defaultOffer(peer.walletParams.trampolineNode.id).first.encode())
                 }
-                get("getaddress") {
+                get("getlnaddress") {
                     call.respond(if (peer.channels.isNotEmpty()) peer.requestAddress("en") else "must have one channel")
                 }
                 get("payments/incoming") {
@@ -210,7 +210,7 @@ class Api(private val nodeParams: NodeParams, private val peer: Peer, private va
                         is fr.acinq.lightning.io.OfferNotPaid -> call.respond(PaymentFailed(event))
                     }
                 }
-                post("paydnsaddress") {
+                post("paylnaddress") {
                     val formParameters = call.receiveParameters()
                     val overrideAmount = formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
                     val (username, domain) = formParameters.getEmailLikeAddress("address")

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/Parser.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/Parser.kt
@@ -1,0 +1,22 @@
+package fr.acinq.lightning.bin.payments
+
+object Parser {
+    fun parseEmailLikeAddress(input: String): Pair<String, String>? {
+        if (!input.contains("@", ignoreCase = true)) return null
+
+        // Ignore excess input, including additional lines, and leading/trailing whitespace
+        val line = input.lines().firstOrNull { it.isNotBlank() }?.trim()
+        val token = line?.split("\\s+".toRegex())?.firstOrNull()
+
+        if (token.isNullOrBlank()) return null
+
+        val components = token.split("@")
+        if (components.size != 2) {
+            return null
+        }
+
+        val username = components[0].lowercase()
+        val domain = components[1]
+        return username to domain
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/PayDnsAddress.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/PayDnsAddress.kt
@@ -1,0 +1,72 @@
+package fr.acinq.lightning.bin.payments
+
+import fr.acinq.bitcoin.utils.Try
+import fr.acinq.lightning.wire.OfferTypes
+import io.ktor.client.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.utils.io.charsets.*
+import kotlinx.serialization.json.*
+
+class PayDnsAddress {
+
+    private val httpClient: HttpClient by lazy {
+        HttpClient {
+            install(ContentNegotiation) {
+                json(json = Json { ignoreUnknownKeys = true })
+                expectSuccess = false
+            }
+        }
+    }
+
+    /**
+     * Resolves dns-based offers.
+     * See https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki.
+     */
+    suspend fun resolveBip353Offer(
+        username: String,
+        domain: String,
+    ): OfferTypes.Offer? {
+
+        val dnsPath = "$username.user._bitcoin-payment.$domain."
+
+        // list of resolvers: https://dnsprivacy.org/public_resolvers/
+        val url = Url("https://dns.google/resolve?name=$dnsPath&type=TXT")
+
+        try {
+            val response = httpClient.get(url)
+            val json = Json.decodeFromString<JsonObject>(response.bodyAsText(Charsets.UTF_8))
+            val status = json["Status"]?.jsonPrimitive?.intOrNull
+            if (status == null || status > 0) throw RuntimeException("invalid status=$status")
+
+            val ad = json["AD"]?.jsonPrimitive?.booleanOrNull
+            if (ad != true) {
+                return null
+            }
+
+            val records = json["Answer"]?.jsonArray
+            if (records.isNullOrEmpty()) {
+                return null
+            }
+
+            val matchingRecord = records.filterIsInstance<JsonObject>().firstOrNull {
+                it["name"]?.jsonPrimitive?.content == dnsPath
+            } ?: return null
+
+            val data = matchingRecord["data"]?.jsonPrimitive?.content ?: return null
+            if (!data.startsWith("bitcoin:")) return null
+            val offerString = data.substringAfter("lno=").substringBefore("?")
+            if (offerString.isBlank()) return null
+
+            return when (val offer = OfferTypes.Offer.decode(offerString)) {
+                is Try.Success -> { offer.result }
+                is Try.Failure -> { null }
+            }
+        } catch (e: Exception) {
+            return null
+        }
+    }
+}

--- a/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
@@ -51,10 +51,10 @@ fun main(args: Array<String>) =
             ListIncomingPayments(),
             CreateInvoice(),
             GetOffer(),
-            GetAddress(),
+            GetLnAddress(),
             PayInvoice(),
             PayOffer(),
-            PayDnsAddress(),
+            PayLnAddress(),
             DecodeInvoice(),
             DecodeOffer(),
             SendToAddress(),
@@ -222,9 +222,9 @@ class GetOffer : PhoenixCliCommand(name = "getoffer", help = "Return a Lightning
     }
 }
 
-class GetAddress : PhoenixCliCommand(name = "getaddress", help = "Return a BIP-353 Lightning address (there must be a channel)") {
+class GetLnAddress : PhoenixCliCommand(name = "getlnaddress", help = "Return a BIP-353 Lightning address (there must be a channel)") {
     override suspend fun httpRequest() = commonOptions.httpClient.use {
-        it.get(url = commonOptions.baseUrl / "getaddress")
+        it.get(url = commonOptions.baseUrl / "getlnaddress")
     }
 }
 
@@ -258,15 +258,15 @@ class PayOffer : PhoenixCliCommand(name = "payoffer", help = "Pay a Lightning of
     }
 }
 
-class PayDnsAddress : PhoenixCliCommand(name = "paydnsaddress", help = "Pay a BIP353 DNS address", printHelpOnEmptyArgs = true) {
-    private val amountSat by option("--amountSat").long()
+class PayLnAddress : PhoenixCliCommand(name = "paylnaddress", help = "Pay a Lightning address (BIP353)", printHelpOnEmptyArgs = true) {
+    private val amountSat by option("--amountSat").long().required()
     private val address by option("--address").required().check { Parser.parseEmailLikeAddress(it) != null }
     private val message by option("--message").help { "Optional payer note" }
     override suspend fun httpRequest(): HttpResponse = commonOptions.httpClient.use {
         it.submitForm(
-            url = (commonOptions.baseUrl / "paydnsaddress").toString(),
+            url = (commonOptions.baseUrl / "paylnaddress").toString(),
             formParameters = parameters {
-                amountSat?.let { append("amountSat", amountSat.toString()) }
+                append("amountSat", amountSat.toString())
                 append("address", address)
                 message?.let { append("message", message.toString()) }
             }

--- a/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
@@ -50,6 +50,7 @@ fun main(args: Array<String>) =
             ListIncomingPayments(),
             CreateInvoice(),
             GetOffer(),
+            GetAddress(),
             PayInvoice(),
             PayOffer(),
             DecodeInvoice(),
@@ -216,6 +217,12 @@ class CreateInvoice : PhoenixCliCommand(name = "createinvoice", help = "Create a
 class GetOffer : PhoenixCliCommand(name = "getoffer", help = "Return a Lightning offer (static invoice)") {
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.get(url = commonOptions.baseUrl / "getoffer")
+    }
+}
+
+class GetAddress : PhoenixCliCommand(name = "getaddress", help = "Return a BIP-353 Lightning address (there must be a channel)") {
+    override suspend fun httpRequest() = commonOptions.httpClient.use {
+        it.get(url = commonOptions.baseUrl / "getaddress")
     }
 }
 


### PR DESCRIPTION
New methods:
- `getlnaddress`: will only return an address if there is a channel
- `paylnaddress`: works the same as `payoffer` although an address must be provided instead of a BOLT12 offer.