### PR TITLE
Validate that mnemonics form a valid BIP-39 seed

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
@@ -5,6 +5,7 @@ import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.Severity
 import co.touchlab.kermit.StaticConfig
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.output.MordantHelpFormatter
@@ -76,7 +77,11 @@ class Phoenixd : CliktCommand() {
     private val seed by option("--seed", help = "Manually provide a 12-words seed", hidden = true, envvar = PHOENIX_SEED)
         .convert { PhoenixSeed(MnemonicCode.toSeed(it, "").toByteVector(), isNew = false) }
         .defaultLazy {
-            val value = getOrGenerateSeed(datadir)
+            val value = try {
+                getOrGenerateSeed(datadir)
+            } catch (t: Throwable) {
+                throw UsageError(t.message, paramName = "seed")
+            }
             if (value.isNew) {
                 terminal.print(yellow("Generating new seed..."))
                 runBlocking { delay(500.milliseconds) }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/Seed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/Seed.kt
@@ -16,11 +16,12 @@ data class PhoenixSeed(val seed: ByteVector, val isNew: Boolean)
 fun getOrGenerateSeed(dir: Path): PhoenixSeed {
     val file = dir / "seed.dat"
     val (mnemonics, isNew) = if (FileSystem.SYSTEM.exists(file)) {
-        FileSystem.SYSTEM.read(file) { readUtf8() } to false
+        val mnemonics = FileSystem.SYSTEM.read(file) { readUtf8() }.trim().split(" ", "\n").map { it.trim() }
+        mnemonics to false
     } else {
         val entropy = randomBytes(16)
-        val mnemonics = MnemonicCode.toMnemonics(entropy).joinToString(" ")
-        FileSystem.SYSTEM.write(file) { writeUtf8(mnemonics) }
+        val mnemonics = MnemonicCode.toMnemonics(entropy)
+        FileSystem.SYSTEM.write(file) { writeUtf8(mnemonics.joinToString(" ")) }
         mnemonics to true
     }
     MnemonicCode.validate(mnemonics)

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/Seed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/Seed.kt
@@ -16,7 +16,8 @@ data class PhoenixSeed(val seed: ByteVector, val isNew: Boolean)
 fun getOrGenerateSeed(dir: Path): PhoenixSeed {
     val file = dir / "seed.dat"
     val (mnemonics, isNew) = if (FileSystem.SYSTEM.exists(file)) {
-        val mnemonics = FileSystem.SYSTEM.read(file) { readUtf8() }.trim().split(" ", "\n").map { it.trim() }
+        val contents = FileSystem.SYSTEM.read(file) { readUtf8() }
+        val mnemonics = Regex("[a-z]+").findAll(contents).map { it.value }.toList()
         mnemonics to false
     } else {
         val entropy = randomBytes(16)

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/Seed.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/Seed.kt
@@ -23,5 +23,6 @@ fun getOrGenerateSeed(dir: Path): PhoenixSeed {
         FileSystem.SYSTEM.write(file) { writeUtf8(mnemonics) }
         mnemonics to true
     }
+    MnemonicCode.validate(mnemonics)
     return PhoenixSeed(seed = MnemonicCode.toSeed(mnemonics, "").toByteVector(), isNew = isNew)
 }


### PR DESCRIPTION
We were generating a valid BIP39 seed, but did not enfore any constraints at reading and would accept any phrase. We now always verify that we use a valid BIP-39 seed.

Fixes #65.