### PR TITLE
Fix offer extraction in BIP-21 uris

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -127,7 +127,6 @@ class Api(
                         blockHeight = peer.currentTipFlow.value,
                         version = BuildVersions.phoenixdVersion
                     )
-                    call.request.uri
                     call.respond(info)
                 }
                 get("getbalance") {

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -127,6 +127,7 @@ class Api(
                         blockHeight = peer.currentTipFlow.value,
                         version = BuildVersions.phoenixdVersion
                     )
+                    call.request.uri
                     call.respond(info)
                 }
                 get("getbalance") {

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/Parser.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/Parser.kt
@@ -1,5 +1,8 @@
 package fr.acinq.lightning.bin.payments
 
+import fr.acinq.bitcoin.utils.Try
+import fr.acinq.lightning.wire.OfferTypes
+
 object Parser {
     fun parseEmailLikeAddress(input: String): Pair<String, String>? {
         if (!input.contains("@", ignoreCase = true)) return null
@@ -18,5 +21,15 @@ object Parser {
         val username = components[0].lowercase().dropWhile { it == '₿' }
         val domain = components[1]
         return username to domain
+    }
+
+    fun parseBip21Offer(uri: String): OfferTypes.Offer? {
+        if (!uri.startsWith("bitcoin:")) return null
+        val offerString = uri.substringAfter("lno=").substringBefore("&")
+        if (offerString.isBlank()) return null
+        return when (val offer = OfferTypes.Offer.decode(offerString)) {
+            is Try.Success -> offer.result
+            is Try.Failure -> null
+        }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/Parser.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/Parser.kt
@@ -2,6 +2,7 @@ package fr.acinq.lightning.bin.payments
 
 import fr.acinq.bitcoin.utils.Try
 import fr.acinq.lightning.wire.OfferTypes
+import io.ktor.http.*
 
 object Parser {
     fun parseEmailLikeAddress(input: String): Pair<String, String>? {
@@ -24,12 +25,13 @@ object Parser {
     }
 
     fun parseBip21Offer(uri: String): OfferTypes.Offer? {
-        if (!uri.startsWith("bitcoin:")) return null
-        val offerString = uri.substringAfter("lno=").substringBefore("&")
-        if (offerString.isBlank()) return null
-        return when (val offer = OfferTypes.Offer.decode(offerString)) {
-            is Try.Success -> offer.result
-            is Try.Failure -> null
+        val url = Url(uri)
+        if (url.protocol.name != "bitcoin") return null
+        return url.parameters["lno"]?.let {
+            when (val offer = OfferTypes.Offer.decode(it)) {
+                is Try.Success -> offer.result
+                is Try.Failure -> null
+            }
         }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/PayDnsAddress.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/payments/PayDnsAddress.kt
@@ -57,14 +57,7 @@ class PayDnsAddress {
             } ?: return null
 
             val data = matchingRecord["data"]?.jsonPrimitive?.content ?: return null
-            if (!data.startsWith("bitcoin:")) return null
-            val offerString = data.substringAfter("lno=").substringBefore("?")
-            if (offerString.isBlank()) return null
-
-            return when (val offer = OfferTypes.Offer.decode(offerString)) {
-                is Try.Success -> { offer.result }
-                is Try.Failure -> { null }
-            }
+            return Parser.parseBip21Offer(data)
         } catch (e: Exception) {
             return null
         }

--- a/src/commonTest/kotlin/fr/acinq/lightning/bin/payments/ParserTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/bin/payments/ParserTestsCommon.kt
@@ -35,6 +35,7 @@ class ParserTestsCommon {
             TestCase("not-an-uri", null),
             TestCase("notbitcoin:?lno=$offer", null),
             TestCase("bitcoin:?foo=bar&bar=baz", null),
+            TestCase("bitcoin:tb1qla78tll0eua3l5f4nvfq3tx58u35yc3m44flfu?time=1618931109&exp=604800", null),
         )
 
         testCases.forEach { testCase -> assertEquals(testCase.offer, Parser.parseBip21Offer(testCase.uri)) }

--- a/src/commonTest/kotlin/fr/acinq/lightning/bin/payments/ParserTestsCommon.kt
+++ b/src/commonTest/kotlin/fr/acinq/lightning/bin/payments/ParserTestsCommon.kt
@@ -1,5 +1,6 @@
 package fr.acinq.lightning.bin.payments
 
+import fr.acinq.lightning.wire.OfferTypes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -9,12 +10,33 @@ class ParserTestsCommon {
     fun `test address parsing`() {
         data class TestCase(val address: String, val user: String, val domain: String)
 
-        val testcases = listOf(
+        val testCases = listOf(
             TestCase("foo@bar.com", "foo", "bar.com"),
             TestCase("₿foo@bar.com", "foo", "bar.com"),
             TestCase("₿₿foo@bar.com", "foo", "bar.com"),
         )
 
-        testcases.forEach { testCase -> assertEquals(testCase.user to testCase.domain, Parser.parseEmailLikeAddress(testCase.address)) }
+        testCases.forEach { testCase -> assertEquals(testCase.user to testCase.domain, Parser.parseEmailLikeAddress(testCase.address)) }
+    }
+
+    @Test
+    fun `test bip21 parsing`() {
+        data class TestCase(val uri: String, val offer: OfferTypes.Offer?)
+
+        val offer =
+            OfferTypes.Offer.decode("lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqqsespexwyy4tcadvgg89l9aljus6709kx235hhqrk6n8dey98uyuftzdqzrtkahuum7m56dxlnx8r6tffy54004l7kvs7pylmxx7xs4n54986qyqeeuhhunayntt50snmdkq4t7fzsgghpl69v9csgparek8kv7dlp5uqr8ymp5s4z9upmwr2s8xu020d45t5phqc8nljrq8gzsjmurzevawjz6j6rc95xwfvnhgfx6v4c3jha7jwynecrz3y092nn25ek4yl7xp9yu9ry9zqagt0ktn4wwvqg52v9ss9ls22sqyqqestzp2l6decpn87pq96udsvx")
+                .get()
+
+        val testCases = listOf(
+            TestCase("bitcoin:?lno=$offer", offer),
+            TestCase("bitcoin:?lno=$offer&foo=bar", offer),
+            TestCase("bitcoin:?foo=bar&lno=$offer", offer),
+            TestCase("bitcoin:?foo=bar&lno=$offer&bar=baz", offer),
+            TestCase("not-an-uri", null),
+            TestCase("notbitcoin:?lno=$offer", null),
+            TestCase("bitcoin:?foo=bar&bar=baz", null),
+        )
+
+        testCases.forEach { testCase -> assertEquals(testCase.offer, Parser.parseBip21Offer(testCase.uri)) }
     }
 }


### PR DESCRIPTION
We weren't correctly parsing BIP21 uris containing multiple fields.