### PR TITLE
Support multiple values in configuration file

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
@@ -15,7 +15,6 @@ import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.restrictTo
-import com.github.ajalt.clikt.sources.MapValueSource
 import com.github.ajalt.mordant.rendering.TextColors.*
 import com.github.ajalt.mordant.rendering.TextStyles.bold
 import fr.acinq.bitcoin.Chain
@@ -27,9 +26,9 @@ import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.PaymentEvents
 import fr.acinq.lightning.bin.conf.EnvVars.PHOENIX_SEED
 import fr.acinq.lightning.bin.conf.LSP
+import fr.acinq.lightning.bin.conf.ListValueSource
 import fr.acinq.lightning.bin.conf.PhoenixSeed
 import fr.acinq.lightning.bin.conf.getOrGenerateSeed
-import fr.acinq.lightning.bin.conf.readConfFile
 import fr.acinq.lightning.bin.db.SqliteChannelsDb
 import fr.acinq.lightning.bin.db.SqlitePaymentsDb
 import fr.acinq.lightning.bin.db.WalletPaymentId
@@ -171,7 +170,7 @@ class Phoenixd : CliktCommand() {
     init {
         FileSystem.SYSTEM.createDirectories(datadir)
         context {
-            valueSource = MapValueSource(readConfFile(confFile))
+            valueSource = ListValueSource.fromFile(confFile)
             helpFormatter = { MordantHelpFormatter(it, showDefaultValues = true) }
         }
     }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/ConfFile.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/ConfFile.kt
@@ -3,17 +3,14 @@ package fr.acinq.lightning.bin.conf
 import okio.FileSystem
 import okio.Path
 
-fun readConfFile(confFile: Path): Map<String, String> = try {
-    buildMap {
+fun readConfFile(confFile: Path): List<Pair<String, String>> =
+    buildList {
         if (FileSystem.SYSTEM.exists(confFile)) {
             FileSystem.SYSTEM.read(confFile) {
                 while (true) {
                     val line = readUtf8Line() ?: break
-                    line.split("=").run { put(first(), last()) }
+                    line.split("=").run { add(first() to last()) }
                 }
             }
         }
     }
-} catch (t: Throwable) {
-    emptyMap()
-}

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/ListValueSource.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/ListValueSource.kt
@@ -1,0 +1,25 @@
+package fr.acinq.lightning.bin.conf
+
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.parameters.options.Option
+import com.github.ajalt.clikt.sources.ValueSource
+import okio.Path
+
+/**
+ * Very similar to [com.github.ajalt.clikt.sources.MapValueSource], but backed by a [List]
+ * in order to allow multiple invocations (e.g. ```--arg foo --arg bar```).
+ */
+class ListValueSource(
+    private val values: List<Pair<String, String>>,
+    private val getKey: (Context, Option) -> String = ValueSource.getKey(joinSubcommands = "."),
+) : ValueSource {
+    override fun getValues(context: Context, option: Option): List<ValueSource.Invocation> {
+        return values
+            .filter { it.first == (option.valueSourceKey ?: getKey(context, option)) }
+            .map { ValueSource.Invocation.value(it.second) }
+    }
+
+    companion object {
+        fun fromFile(confFile: Path): ListValueSource = ListValueSource(readConfFile(confFile))
+    }
+}


### PR DESCRIPTION
Use a `ListValueSource` instead of the built-in `MapValueSource`, which didn't not support duplicate configuration value.

Supporting multiple configuration values is useful for e.g. #72:
```
chain=testnet
webhook=https://1.webhook.net
webhook=https://2.webhook.net
```