### PR TITLE
Add a secondary http password with limited access

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
@@ -107,12 +107,21 @@ class Phoenixd : CliktCommand() {
         .default(10.minutes)
     private val httpBindIp by option("--http-bind-ip", help = "Bind ip for the http api").default("127.0.0.1")
     private val httpBindPort by option("--http-bind-port", help = "Bind port for the http api").int().default(9740)
-    private val httpPassword by option("--http-password", help = "Password for the http api")
+    private val httpPassword by option("--http-password", help = "Password for the http api (full access)")
         .defaultLazy {
             // if we are here then no value is defined in phoenix.conf
             terminal.print(yellow("Generating default api password..."))
             val value = randomBytes32().toHex()
             FileSystem.SYSTEM.appendingSink(confFile, mustExist = false).buffer().use { it.writeUtf8("\nhttp-password=$value") }
+            terminal.println(white("done"))
+            value
+        }
+    private val httpPasswordLimitedAccess by option("--http-password-limited-access", help = "Password for the http api (limited access)")
+        .defaultLazy {
+            // if we are here then no value is defined in phoenix.conf
+            terminal.print(yellow("Generating default api password..."))
+            val value = randomBytes32().toHex()
+            FileSystem.SYSTEM.appendingSink(confFile, mustExist = false).buffer().use { it.writeUtf8("\nhttp-password-limited-access=$value") }
             terminal.println(white("done"))
             value
         }
@@ -370,7 +379,7 @@ class Phoenixd : CliktCommand() {
                 reuseAddress = true
             },
             module = {
-                Api(nodeParams, peer, eventsFlow, httpPassword, webHookUrls, webHookSecret, loggerFactory).run { module() }
+                Api(nodeParams, peer, eventsFlow, httpPassword, httpPasswordLimitedAccess, webHookUrls, webHookSecret, loggerFactory).run { module() }
             }
         )
         val serverJob = scope.launch {

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
@@ -119,7 +119,7 @@ class Phoenixd : CliktCommand() {
     private val httpPasswordLimitedAccess by option("--http-password-limited-access", help = "Password for the http api (limited access)")
         .defaultLazy {
             // if we are here then no value is defined in phoenix.conf
-            terminal.print(yellow("Generating default api password..."))
+            terminal.print(yellow("Generating limited access api password..."))
             val value = randomBytes32().toHex()
             FileSystem.SYSTEM.appendingSink(confFile, mustExist = false).buffer().use { it.writeUtf8("\nhttp-password-limited-access=$value") }
             terminal.println(white("done"))


### PR DESCRIPTION
Add a separate password `--http-password-limited-access` that grants limited access the http api for security purposes. Essentially, this limited access password doesn't allow the spending of funds.

This secondary password is less sensitive than the primary password, but it must still *not be shared*, as other attacks are possible, e.g. resource exhaustion by creating millions of invoices, etc.

The following api methods are not available with limited access:
- `payinvoice`
- `payoffer`
- `paylnaddress`
- `lnurlpay`
- `lnurlauth`
- `sendtoaddress`
- `closechannel`

Closes #74.