### PR TITLE
Add a per-invoice webhook for BOLT11 payments

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -157,7 +157,7 @@ class Api(
                     val externalId = formParameters["externalId"]
                     val webhookUrl = formParameters.getOptionalUrl("webhookUrl")
                     if (externalId != null || webhookUrl != null) {
-                        paymentDb.metadataQueries.insertExternalId(WalletPaymentId.IncomingPaymentId(invoice.paymentHash), externalId, webhookUrl)
+                        paymentDb.metadataQueries.insert(WalletPaymentId.IncomingPaymentId(invoice.paymentHash), externalId, webhookUrl)
                     }
                     call.respond(GeneratedInvoice(invoice.amount?.truncateToSatoshi(), invoice.paymentHash, serialized = invoice.write()))
                 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -53,6 +53,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -153,8 +154,10 @@ class Api(
                         else -> badRequest("Must provide either a description or descriptionHash")
                     }
                     val invoice = peer.createInvoice(randomBytes32(), amount?.toMilliSatoshi(), eitherDesc)
-                    formParameters["externalId"]?.takeUnless { it.isBlank() }?.let { externalId ->
-                        paymentDb.metadataQueries.insertExternalId(WalletPaymentId.IncomingPaymentId(invoice.paymentHash), externalId)
+                    val externalId = formParameters["externalId"]
+                    val webhookUrl = formParameters.getOptionalUrl("webhookUrl")
+                    if (externalId != null || webhookUrl != null) {
+                        paymentDb.metadataQueries.insertExternalId(WalletPaymentId.IncomingPaymentId(invoice.paymentHash), externalId, webhookUrl)
                     }
                     call.respond(GeneratedInvoice(invoice.amount?.truncateToSatoshi(), invoice.paymentHash, serialized = invoice.write()))
                 }
@@ -372,33 +375,44 @@ class Api(
             }
         }
 
+        val client = HttpClient {
+            install(io.ktor.client.plugins.contentnegotiation.ContentNegotiation) {
+                json(json = Json {
+                    prettyPrint = true
+                    isLenient = true
+                })
+            }
+        }
+        client.sendPipeline.intercept(HttpSendPipeline.State) {
+            when (val body = context.body) {
+                is TextContent -> {
+                    val bodyBytes = body.text.encodeUtf8()
+                    val secretBytes = webhookSecret.encodeUtf8()
+                    val sig = bodyBytes.hmacSha256(secretBytes)
+                    context.headers.append("X-Phoenix-Signature", sig.hex())
+                }
+            }
+        }
+        suspend fun notifyWebhook(url: Url, event: ApiEvent) {
+            println("posting webhook to $url")
+            client.post(url) {
+                contentType(ContentType.Application.Json)
+                setBody(event)
+            }
+        }
+        // general webhook urls
         webhookUrls.forEach { url ->
-            val client = HttpClient {
-                install(io.ktor.client.plugins.contentnegotiation.ContentNegotiation) {
-                    json(json = Json {
-                        prettyPrint = true
-                        isLenient = true
-                    })
-                }
-            }
-            client.sendPipeline.intercept(HttpSendPipeline.State) {
-                when (val body = context.body) {
-                    is TextContent -> {
-                        val bodyBytes = body.text.encodeUtf8()
-                        val secretBytes = webhookSecret.encodeUtf8()
-                        val sig = bodyBytes.hmacSha256(secretBytes)
-                        context.headers.append("X-Phoenix-Signature", sig.hex())
-                    }
-                }
-            }
             launch {
-                eventsFlow.collect { event ->
-                    client.post(url) {
-                        contentType(ContentType.Application.Json)
-                        setBody(event)
-                    }
-                }
+                eventsFlow.collect { event -> notifyWebhook(url, event) }
             }
+        }
+        // per-event webhook url
+        launch {
+            eventsFlow
+                .filterIsInstance<PaymentReceived>()
+                .collect { event ->
+                    event.webhookUrl?.let { url -> notifyWebhook(url, event) }
+                }
         }
     }
 
@@ -433,4 +447,6 @@ class Api(
     private fun Parameters.getLnurl(argName: String): Lnurl = this[argName]?.let { LnurlParser.extractLnurl(it) } ?: missing(argName)
 
     private fun Parameters.getLnurlAuth(argName: String): LnurlAuth = this[argName]?.let { LnurlParser.extractLnurl(it) as LnurlAuth } ?: missing(argName)
+
+    private fun Parameters.getOptionalUrl(argName: String): Url? = this[argName]?.let { runCatching { Url(it) }.getOrNull() ?: invalidType(argName, "url") }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/db/PaymentsMetadata.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/db/PaymentsMetadata.kt
@@ -1,13 +1,17 @@
 package fr.acinq.lightning.bin.db
 
+import io.ktor.http.*
+
 /**
  * Metadata for a given payment, incoming or outgoing.
  *
- * @param externalId A custom identifier used in an external system  and attached to a payment at creation.
+ * @param externalId A custom identifier used in an external system and attached to a payment at creation.
  *              Useful to track a payment from the outside.
+ * @param webhookUrl A webhook url that will be notified for that specific payment.
  * @param createdAt Timestamp in millis when the metadata was created.
  */
 data class PaymentMetadata(
     val externalId: String?,
+    val webhookUrl: Url?,
     val createdAt: Long
 )

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/db/payments/PaymentsMetadataQueries.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/db/payments/PaymentsMetadataQueries.kt
@@ -15,7 +15,7 @@ class PaymentsMetadataQueries(private val database: PhoenixDatabase) {
             .executeAsOneOrNull()
     }
 
-    fun insertExternalId(walletPaymentId: WalletPaymentId, externalId: String?, webhookUrl: Url?) {
+    fun insert(walletPaymentId: WalletPaymentId, externalId: String?, webhookUrl: Url?) {
         database.transaction {
             queries.insert(type = walletPaymentId.dbType.value, id = walletPaymentId.dbId, external_id = externalId, webhook_url =  webhookUrl.toString(), created_at = currentTimestampMillis())
         }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
@@ -24,7 +24,7 @@ import fr.acinq.lightning.bin.payments.lnurl.models.Lnurl
 import fr.acinq.lightning.bin.payments.lnurl.models.LnurlWithdraw
 import fr.acinq.lightning.channel.states.ChannelState
 import fr.acinq.lightning.channel.states.ChannelStateWithCommitments
-import fr.acinq.lightning.db.*
+import fr.acinq.lightning.db.LightningOutgoingPayment
 import fr.acinq.lightning.json.JsonSerializers
 import fr.acinq.lightning.payment.Bolt11Invoice
 import fr.acinq.lightning.utils.UUID
@@ -32,8 +32,8 @@ import io.ktor.http.*
 import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.UseSerializers
-import kotlin.math.ln
 
 sealed class ApiType {
 
@@ -83,8 +83,8 @@ sealed class ApiType {
 
     @Serializable
     @SerialName("payment_received")
-    data class PaymentReceived(@SerialName("amountSat") val amount: Satoshi, val paymentHash: ByteVector32, val externalId: String?) : ApiEvent() {
-        constructor(event: fr.acinq.lightning.PaymentEvents.PaymentReceived, metadata: PaymentMetadata?) : this(event.amount.truncateToSatoshi(), event.paymentHash, metadata?.externalId)
+    data class PaymentReceived(@SerialName("amountSat") val amount: Satoshi, val paymentHash: ByteVector32, val externalId: String?, @Transient val webhookUrl: Url? = null) : ApiEvent() {
+        constructor(event: fr.acinq.lightning.PaymentEvents.PaymentReceived, metadata: PaymentMetadata?) : this(event.amount.truncateToSatoshi(), event.paymentHash, metadata?.externalId, metadata?.webhookUrl)
     }
 
     @Serializable

--- a/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
@@ -207,16 +207,18 @@ class CreateInvoice : PhoenixCliCommand(name = "createinvoice", help = "Create a
     ).single().required()
 
     private val externalId by option("--externalId")
+    private val webhookUrl by option("--webhookUrl")
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.submitForm(
             url = (commonOptions.baseUrl / "createinvoice").toString(),
             formParameters = parameters {
                 amountSat?.let { append("amountSat", it.toString()) }
-                externalId?.let { append("externalId", it) }
                 when (val d = description) {
                     is Either.Left -> append("description", d.value)
                     is Either.Right -> append("descriptionHash", d.value.toHex())
                 }
+                externalId?.let { append("externalId", it) }
+                webhookUrl?.let { append("webhookUrl", it) }
             }
         )
     }

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/PaymentsMetadata.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/PaymentsMetadata.sq
@@ -5,7 +5,8 @@
 CREATE TABLE IF NOT EXISTS payments_metadata (
     type INTEGER NOT NULL,
     id TEXT NOT NULL,
-    external_id TEXT NOT NULL,
+    external_id TEXT,
+    webhook_url TEXT,
     created_at INTEGER NOT NULL,
     PRIMARY KEY (type, id)
 );
@@ -19,13 +20,10 @@ INSERT INTO payments_metadata (
             type,
             id,
             external_id,
+            webhook_url,
             created_at
-) VALUES (?, ?, ?, ?);
+) VALUES (?, ?, ?, ?, ?);
 
 get:
-SELECT external_id, created_at FROM payments_metadata
+SELECT external_id, webhook_url, created_at FROM payments_metadata
 WHERE type = ? AND id = ?;
-
-getByExternalId:
-SELECT type, id, external_id, created_at FROM payments_metadata
-WHERE external_id = ?;

--- a/src/commonMain/sqldelight/phoenixdb/migrations/1.sqm
+++ b/src/commonMain/sqldelight/phoenixdb/migrations/1.sqm
@@ -1,0 +1,34 @@
+-- Migration: v1 -> v2
+--
+-- Changes:
+-- * Made column external_id nullable
+-- * Added column webhook_url
+
+CREATE TABLE payments_metadata_backup (
+    type INTEGER NOT NULL,
+    id TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (type, id)
+);
+
+INSERT INTO payments_metadata_backup SELECT * FROM payments_metadata;
+
+DROP TABLE payments_metadata;
+
+CREATE TABLE payments_metadata (
+    type INTEGER NOT NULL,
+    id TEXT NOT NULL,
+    external_id TEXT,
+    webhook_url TEXT,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (type, id)
+);
+
+CREATE INDEX IF NOT EXISTS payments_metadata_external_id ON payments_metadata(external_id);
+
+INSERT INTO payments_metadata SELECT type, id, external_id, NULL, created_at FROM payments_metadata_backup;
+
+DROP TABLE payments_metadata_backup;
+
+

--- a/src/jvmMain/kotlin/fr/acinq/lightning/bin/Actuals.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/bin/Actuals.kt
@@ -14,6 +14,8 @@ actual val datadir: Path = (System.getenv()[PHOENIX_DATADIR]?.toPath() ?: System
 
 actual fun createAppDbDriver(dir: Path, chain: Chain, nodeId: PublicKey): SqlDriver {
     val path = dir / "phoenix.${chain.name.lowercase()}.${nodeId.toHex().take(6)}.db"
+    // We have to use migrateEmptySchema = true because for the first release we called Schema.create(driver), which
+    // didn't set the version to 1.
     val driver = JdbcSqliteDriver("jdbc:sqlite:$path", Properties(), PhoenixDatabase.Schema, migrateEmptySchema = true)
     return driver
 }

--- a/src/jvmMain/kotlin/fr/acinq/lightning/bin/Actuals.kt
+++ b/src/jvmMain/kotlin/fr/acinq/lightning/bin/Actuals.kt
@@ -8,12 +8,12 @@ import fr.acinq.lightning.bin.conf.EnvVars.PHOENIX_DATADIR
 import fr.acinq.phoenix.db.PhoenixDatabase
 import okio.Path
 import okio.Path.Companion.toPath
+import java.util.*
 
 actual val datadir: Path = (System.getenv()[PHOENIX_DATADIR]?.toPath() ?: System.getProperty("user.home").toPath().div(".phoenix"))
 
 actual fun createAppDbDriver(dir: Path, chain: Chain, nodeId: PublicKey): SqlDriver {
     val path = dir / "phoenix.${chain.name.lowercase()}.${nodeId.toHex().take(6)}.db"
-    val driver = JdbcSqliteDriver("jdbc:sqlite:$path")
-    PhoenixDatabase.Schema.create(driver)
+    val driver = JdbcSqliteDriver("jdbc:sqlite:$path", Properties(), PhoenixDatabase.Schema, migrateEmptySchema = true)
     return driver
 }


### PR DESCRIPTION
A new `--webhookUrl` parameter has been added to `createinvoice` and will be notified when that specific payment has been received, in addition to the normal webhook(s) defined in configuration. 

Usage:
```
phoenix-cli createinvoice --description "test webhook" --webhookUrl https://my.webhook.net
```

Suggested in #79.