### PR TITLE
(JVM) Fix db schema version

### DIFF
--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/ChannelCloseOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/ChannelCloseOutgoingPayments.sq
@@ -3,7 +3,7 @@ import fr.acinq.lightning.bin.db.payments.ClosingInfoTypeVersion;
 -- Store in a flat row outgoing payments standing for channel-closing.
 -- There are no complex json columns like in the outgoing_payments table.
 -- This table replaces the legacy outgoing_payment_closing_tx_parts table.
-CREATE TABLE  channel_close_outgoing_payments (
+CREATE TABLE channel_close_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     recipient_amount_sat INTEGER NOT NULL,
     address TEXT NOT NULL,

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/ChannelCloseOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/ChannelCloseOutgoingPayments.sq
@@ -3,7 +3,7 @@ import fr.acinq.lightning.bin.db.payments.ClosingInfoTypeVersion;
 -- Store in a flat row outgoing payments standing for channel-closing.
 -- There are no complex json columns like in the outgoing_payments table.
 -- This table replaces the legacy outgoing_payment_closing_tx_parts table.
-CREATE TABLE IF NOT EXISTS channel_close_outgoing_payments (
+CREATE TABLE  channel_close_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     recipient_amount_sat INTEGER NOT NULL,
     address TEXT NOT NULL,

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/Channels.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/Channels.sq
@@ -4,14 +4,14 @@ PRAGMA foreign_keys = 1;
 
 -- channels table
 -- note: boolean are stored as INTEGER, with 0=false
-CREATE TABLE  local_channels (
+CREATE TABLE local_channels (
     channel_id BLOB NOT NULL PRIMARY KEY,
     data BLOB NOT NULL,
     is_closed INTEGER AS Boolean DEFAULT 0 NOT NULL
 );
 
 -- htlcs info table
-CREATE TABLE  htlc_infos (
+CREATE TABLE htlc_infos (
     channel_id BLOB NOT NULL,
     commitment_number INTEGER NOT NULL,
     payment_hash BLOB NOT NULL,
@@ -19,7 +19,7 @@ CREATE TABLE  htlc_infos (
     FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id)
 );
 
-CREATE INDEX  htlc_infos_idx ON htlc_infos(channel_id, commitment_number);
+CREATE INDEX htlc_infos_idx ON htlc_infos(channel_id, commitment_number);
 
 -- channels queries
 getChannel:

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/Channels.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/Channels.sq
@@ -4,14 +4,14 @@ PRAGMA foreign_keys = 1;
 
 -- channels table
 -- note: boolean are stored as INTEGER, with 0=false
-CREATE TABLE IF NOT EXISTS local_channels (
+CREATE TABLE  local_channels (
     channel_id BLOB NOT NULL PRIMARY KEY,
     data BLOB NOT NULL,
     is_closed INTEGER AS Boolean DEFAULT 0 NOT NULL
 );
 
 -- htlcs info table
-CREATE TABLE IF NOT EXISTS htlc_infos (
+CREATE TABLE  htlc_infos (
     channel_id BLOB NOT NULL,
     commitment_number INTEGER NOT NULL,
     payment_hash BLOB NOT NULL,
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS htlc_infos (
     FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id)
 );
 
-CREATE INDEX IF NOT EXISTS htlc_infos_idx ON htlc_infos(channel_id, commitment_number);
+CREATE INDEX  htlc_infos_idx ON htlc_infos(channel_id, commitment_number);
 
 -- channels queries
 getChannel:

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/InboundLiquidityOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/InboundLiquidityOutgoingPayments.sq
@@ -2,7 +2,7 @@ import fr.acinq.lightning.bin.db.payments.InboundLiquidityLeaseTypeVersion;
 
 -- Stores in a flat row payments standing for an inbound liquidity request (which are done through a splice).
 -- The lease data are stored in a complex column, as a json-encoded blob. See InboundLiquidityLeaseType file.
-CREATE TABLE IF NOT EXISTS inbound_liquidity_outgoing_payments (
+CREATE TABLE  inbound_liquidity_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     mining_fees_sat INTEGER NOT NULL,
     channel_id BLOB NOT NULL,

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/InboundLiquidityOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/InboundLiquidityOutgoingPayments.sq
@@ -2,7 +2,7 @@ import fr.acinq.lightning.bin.db.payments.InboundLiquidityLeaseTypeVersion;
 
 -- Stores in a flat row payments standing for an inbound liquidity request (which are done through a splice).
 -- The lease data are stored in a complex column, as a json-encoded blob. See InboundLiquidityLeaseType file.
-CREATE TABLE  inbound_liquidity_outgoing_payments (
+CREATE TABLE inbound_liquidity_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     mining_fees_sat INTEGER NOT NULL,
     channel_id BLOB NOT NULL,

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
@@ -2,7 +2,7 @@ import fr.acinq.lightning.bin.db.payments.IncomingOriginTypeVersion;
 import fr.acinq.lightning.bin.db.payments.IncomingReceivedWithTypeVersion;
 
 -- incoming payments
-CREATE TABLE IF NOT EXISTS incoming_payments (
+CREATE TABLE  incoming_payments (
     payment_hash BLOB NOT NULL PRIMARY KEY,
     preimage BLOB NOT NULL,
     created_at INTEGER NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS incoming_payments (
 
 -- Create indexes to optimize the queries in AggregatedQueries.
 -- Tip: Use "explain query plan" to ensure they're actually being used.
-CREATE INDEX IF NOT EXISTS incoming_payments_filter_idx
+CREATE INDEX  incoming_payments_filter_idx
     ON incoming_payments(received_at)
  WHERE received_at IS NOT NULL;
 

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/IncomingPayments.sq
@@ -2,7 +2,7 @@ import fr.acinq.lightning.bin.db.payments.IncomingOriginTypeVersion;
 import fr.acinq.lightning.bin.db.payments.IncomingReceivedWithTypeVersion;
 
 -- incoming payments
-CREATE TABLE  incoming_payments (
+CREATE TABLE incoming_payments (
     payment_hash BLOB NOT NULL PRIMARY KEY,
     preimage BLOB NOT NULL,
     created_at INTEGER NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE  incoming_payments (
 
 -- Create indexes to optimize the queries in AggregatedQueries.
 -- Tip: Use "explain query plan" to ensure they're actually being used.
-CREATE INDEX  incoming_payments_filter_idx
+CREATE INDEX incoming_payments_filter_idx
     ON incoming_payments(received_at)
  WHERE received_at IS NOT NULL;
 

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LightningOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LightningOutgoingPayments.sq
@@ -8,7 +8,7 @@ PRAGMA foreign_keys = 1;
 
 -- outgoing payments
 -- Stores an outgoing payment in a flat row. Some columns can be null.
-CREATE TABLE IF NOT EXISTS lightning_outgoing_payments (
+CREATE TABLE  lightning_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     recipient_amount_msat INTEGER NOT NULL,
     recipient_node_id TEXT NOT NULL,
@@ -25,11 +25,11 @@ CREATE TABLE IF NOT EXISTS lightning_outgoing_payments (
 
 -- Create indexes to optimize the queries in AggregatedQueries.
 -- Tip: Use "explain query plan" to ensure they're actually being used.
-CREATE INDEX IF NOT EXISTS outgoing_payments_filter_idx
+CREATE INDEX  outgoing_payments_filter_idx
     ON lightning_outgoing_payments(completed_at);
 
 -- Stores the lightning parts that make up a lightning payment
-CREATE TABLE IF NOT EXISTS lightning_outgoing_payment_parts (
+CREATE TABLE  lightning_outgoing_payment_parts (
     part_id TEXT NOT NULL PRIMARY KEY,
     part_parent_id TEXT NOT NULL,
     part_amount_msat INTEGER NOT NULL,
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS lightning_outgoing_payment_parts (
 -- > Indices are not required for child key columns but they are almost always beneficial.
 -- > [...] So, in most real systems, an index should be created on the child key columns
 -- > of each foreign key constraint.
-CREATE INDEX IF NOT EXISTS parent_id_idx ON lightning_outgoing_payment_parts(part_parent_id);
+CREATE INDEX  parent_id_idx ON lightning_outgoing_payment_parts(part_parent_id);
 
 -- queries for outgoing payments
 

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LightningOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LightningOutgoingPayments.sq
@@ -8,7 +8,7 @@ PRAGMA foreign_keys = 1;
 
 -- outgoing payments
 -- Stores an outgoing payment in a flat row. Some columns can be null.
-CREATE TABLE  lightning_outgoing_payments (
+CREATE TABLE lightning_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     recipient_amount_msat INTEGER NOT NULL,
     recipient_node_id TEXT NOT NULL,
@@ -25,11 +25,11 @@ CREATE TABLE  lightning_outgoing_payments (
 
 -- Create indexes to optimize the queries in AggregatedQueries.
 -- Tip: Use "explain query plan" to ensure they're actually being used.
-CREATE INDEX  outgoing_payments_filter_idx
+CREATE INDEX outgoing_payments_filter_idx
     ON lightning_outgoing_payments(completed_at);
 
 -- Stores the lightning parts that make up a lightning payment
-CREATE TABLE  lightning_outgoing_payment_parts (
+CREATE TABLE lightning_outgoing_payment_parts (
     part_id TEXT NOT NULL PRIMARY KEY,
     part_parent_id TEXT NOT NULL,
     part_amount_msat INTEGER NOT NULL,
@@ -49,7 +49,7 @@ CREATE TABLE  lightning_outgoing_payment_parts (
 -- > Indices are not required for child key columns but they are almost always beneficial.
 -- > [...] So, in most real systems, an index should be created on the child key columns
 -- > of each foreign key constraint.
-CREATE INDEX  parent_id_idx ON lightning_outgoing_payment_parts(part_parent_id);
+CREATE INDEX parent_id_idx ON lightning_outgoing_payment_parts(part_parent_id);
 
 -- queries for outgoing payments
 

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LinkTxToPayment.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LinkTxToPayment.sq
@@ -2,7 +2,7 @@
 -- * tx_id => hex identifier of an on-chain transaction
 -- * type  => tracks the type of a payment. The value is an int as defined in the DbType enum
 -- * id    => the identifier of the payment, can be a payment hash (incoming) or a UUID (outgoing)
-CREATE TABLE  link_tx_to_payments (
+CREATE TABLE link_tx_to_payments (
     tx_id BLOB NOT NULL,
     type INTEGER NOT NULL,
     id TEXT NOT NULL,
@@ -11,7 +11,7 @@ CREATE TABLE  link_tx_to_payments (
     PRIMARY KEY (tx_id, type, id)
 );
 
-CREATE INDEX  link_tx_to_payments_txid ON link_tx_to_payments(tx_id);
+CREATE INDEX link_tx_to_payments_txid ON link_tx_to_payments(tx_id);
 
 listUnconfirmed:
 SELECT DISTINCT(tx_id) FROM link_tx_to_payments WHERE confirmed_at IS NULL;

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LinkTxToPayment.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/LinkTxToPayment.sq
@@ -2,7 +2,7 @@
 -- * tx_id => hex identifier of an on-chain transaction
 -- * type  => tracks the type of a payment. The value is an int as defined in the DbType enum
 -- * id    => the identifier of the payment, can be a payment hash (incoming) or a UUID (outgoing)
-CREATE TABLE IF NOT EXISTS link_tx_to_payments (
+CREATE TABLE  link_tx_to_payments (
     tx_id BLOB NOT NULL,
     type INTEGER NOT NULL,
     id TEXT NOT NULL,
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS link_tx_to_payments (
     PRIMARY KEY (tx_id, type, id)
 );
 
-CREATE INDEX IF NOT EXISTS link_tx_to_payments_txid ON link_tx_to_payments(tx_id);
+CREATE INDEX  link_tx_to_payments_txid ON link_tx_to_payments(tx_id);
 
 listUnconfirmed:
 SELECT DISTINCT(tx_id) FROM link_tx_to_payments WHERE confirmed_at IS NULL;

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/PaymentsMetadata.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/PaymentsMetadata.sq
@@ -2,7 +2,7 @@
 -- * type        => the type of a payment, an int as defined in the DbType enum
 -- * id          => the internal identifier of a payment, can be a payment hash (incoming) or a UUID (outgoing)
 -- * external_id => an arbitrary string defined by the user to track the payment in their own system
-CREATE TABLE IF NOT EXISTS payments_metadata (
+CREATE TABLE  payments_metadata (
     type INTEGER NOT NULL,
     id TEXT NOT NULL,
     external_id TEXT,
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS payments_metadata (
     PRIMARY KEY (type, id)
 );
 
-CREATE INDEX IF NOT EXISTS payments_metadata_external_id ON payments_metadata(external_id);
+CREATE INDEX  payments_metadata_external_id ON payments_metadata(external_id);
 
 -- queries for payments_metadata table
 

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/PaymentsMetadata.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/PaymentsMetadata.sq
@@ -2,7 +2,7 @@
 -- * type        => the type of a payment, an int as defined in the DbType enum
 -- * id          => the internal identifier of a payment, can be a payment hash (incoming) or a UUID (outgoing)
 -- * external_id => an arbitrary string defined by the user to track the payment in their own system
-CREATE TABLE  payments_metadata (
+CREATE TABLE payments_metadata (
     type INTEGER NOT NULL,
     id TEXT NOT NULL,
     external_id TEXT,
@@ -11,7 +11,7 @@ CREATE TABLE  payments_metadata (
     PRIMARY KEY (type, id)
 );
 
-CREATE INDEX  payments_metadata_external_id ON payments_metadata(external_id);
+CREATE INDEX payments_metadata_external_id ON payments_metadata(external_id);
 
 -- queries for payments_metadata table
 

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/SpliceCpfpOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/SpliceCpfpOutgoingPayments.sq
@@ -2,7 +2,7 @@ import fr.acinq.lightning.bin.db.payments.OutgoingPartClosingInfoTypeVersion;
 
 -- Store in a flat row the outgoing payments standing for a CPFP (which are done throuh a splice).
 -- There are no complex json columns like in the outgoing_payments table.
-CREATE TABLE IF NOT EXISTS splice_cpfp_outgoing_payments (
+CREATE TABLE  splice_cpfp_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     mining_fees_sat INTEGER NOT NULL,
     channel_id BLOB NOT NULL,

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/SpliceCpfpOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/SpliceCpfpOutgoingPayments.sq
@@ -2,7 +2,7 @@ import fr.acinq.lightning.bin.db.payments.OutgoingPartClosingInfoTypeVersion;
 
 -- Store in a flat row the outgoing payments standing for a CPFP (which are done throuh a splice).
 -- There are no complex json columns like in the outgoing_payments table.
-CREATE TABLE  splice_cpfp_outgoing_payments (
+CREATE TABLE splice_cpfp_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     mining_fees_sat INTEGER NOT NULL,
     channel_id BLOB NOT NULL,

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/SpliceOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/SpliceOutgoingPayments.sq
@@ -1,6 +1,6 @@
 -- store a splice-out payment in a flat row
 -- there are no complex json columns like in the outgoing_payments table
-CREATE TABLE IF NOT EXISTS splice_outgoing_payments (
+CREATE TABLE  splice_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     recipient_amount_sat INTEGER NOT NULL,
     address TEXT NOT NULL,

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/SpliceOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/SpliceOutgoingPayments.sq
@@ -1,6 +1,6 @@
 -- store a splice-out payment in a flat row
 -- there are no complex json columns like in the outgoing_payments table
-CREATE TABLE  splice_outgoing_payments (
+CREATE TABLE splice_outgoing_payments (
     id TEXT NOT NULL PRIMARY KEY,
     recipient_amount_sat INTEGER NOT NULL,
     address TEXT NOT NULL,

--- a/src/commonMain/sqldelight/phoenixdb/migrations/1.sqm
+++ b/src/commonMain/sqldelight/phoenixdb/migrations/1.sqm
@@ -25,7 +25,7 @@ CREATE TABLE payments_metadata (
     PRIMARY KEY (type, id)
 );
 
-CREATE INDEX  payments_metadata_external_id ON payments_metadata(external_id);
+CREATE INDEX payments_metadata_external_id ON payments_metadata(external_id);
 
 INSERT INTO payments_metadata SELECT type, id, external_id, NULL, created_at FROM payments_metadata_backup;
 

--- a/src/commonMain/sqldelight/phoenixdb/migrations/1.sqm
+++ b/src/commonMain/sqldelight/phoenixdb/migrations/1.sqm
@@ -25,7 +25,7 @@ CREATE TABLE payments_metadata (
     PRIMARY KEY (type, id)
 );
 
-CREATE INDEX IF NOT EXISTS payments_metadata_external_id ON payments_metadata(external_id);
+CREATE INDEX  payments_metadata_external_id ON payments_metadata(external_id);
 
 INSERT INTO payments_metadata SELECT type, id, external_id, NULL, created_at FROM payments_metadata_backup;
 


### PR DESCRIPTION
In order to automatically handle migrations, sqldelight uses sqlite's
 User Version PRAGMA to store the schema version.

Unfortunately, in the JVM case we manually created the schema and didn't
 set the version. We need to manually fix that.

See: https://github.com/cashapp/sqldelight/pull/5374