### PR TITLE
Add an alternative authentication method for websocket

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/api/WebsocketProtocolAuthenticationProvider.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/api/WebsocketProtocolAuthenticationProvider.kt
@@ -1,0 +1,36 @@
+package fr.acinq.lightning.bin.api
+
+import io.ktor.http.*
+import io.ktor.server.auth.*
+import io.ktor.server.response.*
+
+/**
+ * Browsers do not support basic auth for websocket.
+ * This [AuthenticationProvider] uses protocols header as a workaround.
+ * See https://stackoverflow.com/a/77060459
+ */
+class WebsocketProtocolAuthenticationProvider(private val _name: String, val validate: suspend (List<HeaderValue>) -> Principal?) : AuthenticationProvider(object : Config(_name) {}) {
+
+    override suspend fun onAuthenticate(context: AuthenticationContext) {
+        val call = context.call
+        val protocols = parseHeaderValue(call.request.headers[HttpHeaders.SecWebSocketProtocol])
+        val principal = validate(protocols)
+
+        val cause = when {
+            principal == null -> AuthenticationFailedCause.InvalidCredentials
+            else -> null
+        }
+
+        if (cause != null) {
+            @Suppress("NAME_SHADOWING")
+            context.challenge("websocket-protocol", cause) { challenge, call ->
+                call.respond(HttpStatusCode.Unauthorized)
+                challenge.complete()
+            }
+        }
+        if (principal != null) {
+            context.principal(name, principal)
+        }
+    }
+
+}


### PR DESCRIPTION
The goal is to be compatible with browsers. Instead of using the basic auth method, we use the standard `Sec-WebSocket-Protocol` header to pass authentication information, as suggested in point 5. of https://stackoverflow.com/a/77060459.

Examples with `websocat`:
- basic auth: 
```
$ websocat --basic-auth :<api-password> ws://127.0.0.1:9740/websocket
```
- protocol:
```
websocat --protocol <api-password> ws://127.0.0.1:9740/websocket
```

cc @remyers
Builds on #94.
Fixes #92.
