### PR TITLE
Add `payerNote` + `payerKey` to incoming payment event

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
@@ -299,8 +299,9 @@ class Phoenixd : CliktCommand() {
                         .collect {
                             when {
                                 it is PaymentEvents.PaymentReceived && it.amount > 0.msat -> {
+                                    val incomingPayment = paymentsDb.getIncomingPayment(it.paymentHash)
                                     val metadata = paymentsDb.metadataQueries.get(WalletPaymentId.IncomingPaymentId(it.paymentHash))
-                                    emit(ApiType.PaymentReceived(it, metadata))
+                                    emit(ApiType.PaymentReceived(it, incomingPayment, metadata))
                                 }
                                 else -> {}
                             }


### PR DESCRIPTION
Examples:
  -  incoming payment record
```
$ ./phoenix-cli getincomingpayment --paymentHash 4c24b8f3edb59bebb7a8e7a2b3aa3edec0fff1e31486a9cb16757c7a48e3ade6
{
    "paymentHash": "4c24b8f3edb59bebb7a8e7a2b3aa3edec0fff1e31486a9cb16757c7a48e3ade6",
    "preimage": "e314efba8185ff74174724ae7ab90a719b6f17e18f6d665b660d99147e9425c3",
    "isPaid": true,
    "receivedSat": 654,
    "fees": 0,
    "payerNote": "Hello there",
    "payerKey": "02a253612063909c59bfa766d3c459a3eb3ec50c51f938099397158200d025f213",
    "completedAt": 1723625140183,
    "createdAt": 1723625140180
}
```
- incoming payment event
```
{
  "type": "payment_received",
  "timestamp": 1723625140215,
  "amountSat": 654,
  "paymentHash": "4c24b8f3edb59bebb7a8e7a2b3aa3edec0fff1e31486a9cb16757c7a48e3ade6",
  "payerNote": "Hello there",
  "payerKey": "02a253612063909c59bfa766d3c459a3eb3ec50c51f938099397158200d025f213"
}
```

cc @remyers
See #91.