### PR TITLE
Add an optional expiry for bolt11 invoices

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -176,7 +176,8 @@ class Api(
                         description == null && descriptionHash != null -> Either.Right(descriptionHash)
                         else -> badRequest("Must provide either a description or descriptionHash")
                     }
-                    val invoice = peer.createInvoice(randomBytes32(), amount?.toMilliSatoshi(), eitherDesc)
+                    val expirySeconds = formParameters.getOptionalLong("expirySeconds")
+                    val invoice = peer.createInvoice(randomBytes32(), amount?.toMilliSatoshi(), eitherDesc, expirySeconds)
                     val externalId = formParameters["externalId"]
                     val webhookUrl = formParameters.getOptionalUrl("webhookUrl")
                     if (externalId != null || webhookUrl != null) {

--- a/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
@@ -205,6 +205,7 @@ class CreateInvoice : PhoenixCliCommand(name = "createinvoice", help = "Create a
         option("--description", "--desc").convert { Either.Left(it) },
         option("--descriptionHash", "--desc-hash").convert { Either.Right(it.toByteVector32()) }
     ).single().required()
+    private val expirySeconds by option("--expirySeconds").long()
 
     private val externalId by option("--externalId")
     private val webhookUrl by option("--webhookUrl")
@@ -217,6 +218,7 @@ class CreateInvoice : PhoenixCliCommand(name = "createinvoice", help = "Create a
                     is Either.Left -> append("description", d.value)
                     is Either.Right -> append("descriptionHash", d.value.toHex())
                 }
+                expirySeconds?.let { append("expirySeconds", it.toString()) }
                 externalId?.let { append("externalId", it) }
                 webhookUrl?.let { append("webhookUrl", it) }
             }


### PR DESCRIPTION
Example:

```bash
./phoenix-cli createinvoice  --description="expiry test" --expirySeconds=60
```

Suggested by @sixside in #99.