### PR TITLE
Add a best-effort method for estimating liquidity fees

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/Lsp.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/conf/Lsp.kt
@@ -2,9 +2,12 @@ package fr.acinq.lightning.bin.conf
 
 import fr.acinq.bitcoin.Chain
 import fr.acinq.bitcoin.PublicKey
+import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.*
+import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
+import fr.acinq.lightning.wire.LiquidityAds
 
 
 data class LSP(val walletParams: WalletParams, val swapInXpub: String) {
@@ -53,27 +56,34 @@ data class LSP(val walletParams: WalletParams, val swapInXpub: String) {
             else -> error("unsupported chain $chain")
         }
 
-//        fun liquidityLeaseRate(amount: Satoshi): LiquidityAds.LeaseRate {
-//            // WARNING : THIS MUST BE KEPT IN SYNC WITH LSP OTHERWISE FUNDING REQUEST WILL BE REJECTED BY PHOENIX
-//            val fundingWeight = if (amount <= 100_000.sat) {
-//                271 * 2 // 2-inputs (wpkh) / 0-change
-//            } else if (amount <= 250_000.sat) {
-//                271 * 2 // 2-inputs (wpkh) / 0-change
-//            } else if (amount <= 500_000.sat) {
-//                271 * 4 // 4-inputs (wpkh) / 0-change
-//            } else if (amount <= 1_000_000.sat) {
-//                271 * 4 // 4-inputs (wpkh) / 0-change
-//            } else {
-//                271 * 6 // 6-inputs (wpkh) / 0-change
-//            }
-//            return LiquidityAds.LeaseRate(
-//                leaseDuration = 0,
-//                fundingWeight = fundingWeight,
-//                leaseFeeProportional = 100, // 1%
-//                leaseFeeBase = 0.sat,
-//                maxRelayFeeProportional = 100,
-//                maxRelayFeeBase = 1_000.msat
-//            )
-//        }
+        fun liquidityFees(amount: Satoshi, feerate: FeeratePerKw, isNew: Boolean): LiquidityAds.LeaseFees {
+            val creationFee = if (isNew) 1_000.sat else 0.sat
+            val leaseRate = liquidityLeaseRate(amount)
+            val leaseFees = leaseRate.fees(feerate, requestedAmount = amount, contributedAmount = amount)
+            return leaseFees.copy(serviceFee = creationFee + leaseFees.serviceFee)
+        }
+
+        private fun liquidityLeaseRate(amount: Satoshi): LiquidityAds.LeaseRate {
+            // WARNING : THIS MUST BE KEPT IN SYNC WITH LSP OTHERWISE FUNDING REQUEST WILL BE REJECTED BY PHOENIX
+            val fundingWeight = if (amount <= 100_000.sat) {
+                271 * 2 // 2-inputs (wpkh) / 0-change
+            } else if (amount <= 250_000.sat) {
+                271 * 2 // 2-inputs (wpkh) / 0-change
+            } else if (amount <= 500_000.sat) {
+                271 * 4 // 4-inputs (wpkh) / 0-change
+            } else if (amount <= 1_000_000.sat) {
+                271 * 4 // 4-inputs (wpkh) / 0-change
+            } else {
+                271 * 6 // 6-inputs (wpkh) / 0-change
+            }
+            return LiquidityAds.LeaseRate(
+                leaseDuration = 0,
+                fundingWeight = fundingWeight,
+                leaseFeeProportional = 100, // 1%
+                leaseFeeBase = 0.sat,
+                maxRelayFeeProportional = 100,
+                maxRelayFeeBase = 1_000.msat
+            )
+        }
     }
 }

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/json/JsonSerializers.kt
@@ -29,6 +29,7 @@ import fr.acinq.lightning.json.JsonSerializers
 import fr.acinq.lightning.payment.Bolt11Invoice
 import fr.acinq.lightning.payment.OfferPaymentMetadata
 import fr.acinq.lightning.utils.UUID
+import fr.acinq.lightning.wire.LiquidityAds
 import io.ktor.http.*
 import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
@@ -73,6 +74,11 @@ sealed class ApiType {
 
     @Serializable
     data class Balance(@SerialName("balanceSat") val amount: Satoshi, @SerialName("feeCreditSat") val feeCredit: Satoshi) : ApiType()
+
+    @Serializable
+    data class LiquidityFees(@SerialName("miningFeeSat") val miningFee: Satoshi, @SerialName("serviceFeeSat") val serviceFee: Satoshi) : ApiType() {
+        constructor(leaseFees: LiquidityAds.LeaseFees) : this(leaseFees.miningFee, leaseFees.serviceFee)
+    }
 
     @Serializable
     data class GeneratedInvoice(@SerialName("amountSat") val amount: Satoshi?, val paymentHash: ByteVector32, val serialized: String) : ApiType()

--- a/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
@@ -47,6 +47,7 @@ fun main(args: Array<String>) =
         .subcommands(
             GetInfo(),
             GetBalance(),
+            EstimateLiquidityFees(),
             ListChannels(),
             GetOutgoingPayment(),
             ListOutgoingPayments(),
@@ -136,6 +137,17 @@ class GetInfo : PhoenixCliCommand(name = "getinfo", help = "Show basic info abou
 class GetBalance : PhoenixCliCommand(name = "getbalance", help = "Returns your current balance") {
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.get(url = commonOptions.baseUrl / "getbalance")
+    }
+}
+
+class EstimateLiquidityFees : PhoenixCliCommand(name = "estimateliquidityfees", help = "Estimates the liquidity fees for a given amount, at current feerates.") {
+    private val amountSat by option("--amountSat").long().required()
+    override suspend fun httpRequest() = commonOptions.httpClient.use {
+        it.get(url = commonOptions.baseUrl / "estimateliquidityfees") {
+            url {
+                parameters.append("amountSat", amountSat.toString())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Returns a best-effort **estimate** of liquidity fees for a given amount.

Note that:
- it depends on the current mining feerate, which is volatile
- this estimate is the full cost, it doesn't take into account the `fee credit` (which will be deduced)
- if you receive `A` sat with a setting of `--auto-liquidity B`, then the actual liquidity amount will be `A+B` sat.

```
./phoenix-cli estimateliquidityfees --amountSat 2000000
{
    "miningFeeSat": 1219,
    "serviceFeeSat": 20000
}

```

See #88,#104.