### PR TITLE
Upgrade to lightning-kmp 1.8.2

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     val kotlin = "1.9.23"
-    val lightningKmp = "1.8.0"
+    val lightningKmp = "1.8.1"
     val sqlDelight = "2.0.1"
     val okio = "3.8.0"
     val clikt = "4.2.2"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     val kotlin = "1.9.23"
-    val lightningKmp = "1.8.1"
+    val lightningKmp = "1.8.2"
     val sqlDelight = "2.0.1"
     val okio = "3.8.0"
     val clikt = "4.2.2"

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Main.kt
@@ -244,6 +244,7 @@ class Phoenixd : CliktCommand() {
             maxAbsoluteFee = liquidityOptions.maxMiningFee,
             maxRelativeFeeBasisPoints = liquidityOptions.maxRelativeFeeBasisPoints,
             skipAbsoluteFeeCheck = false,
+            considerOnlyMiningFeeForAbsoluteFeeCheck = true,
             maxAllowedFeeCredit = liquidityOptions.maxFeeCredit
         )
         val keyManager = LocalKeyManager(seed.seed, chain, lsp.swapInXpub)

--- a/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/InboundLiquidityOutgoingPayments.sq
+++ b/src/commonMain/sqldelight/phoenixdb/fr/acinq/phoenix/db/InboundLiquidityOutgoingPayments.sq
@@ -1,5 +1,5 @@
 -- Stores in a flat row payments standing for an inbound liquidity request (which are done through a splice).
--- The purchase data are stored in a complex column, as a json-encoded blob. See InboundLiquidityLeaseType file.
+-- The purchase data are stored in a complex column, as a json-encoded blob.
 --
 -- Note that these purchase data used to be called "lease" in the old on-the-fly channel mechanism, that's why the
 -- colum uses that name, it's a legacy artifact. They now map to a "LiquidityAds.Purchase" object.


### PR DESCRIPTION
This PR upgrades phoenixd to use lightning-kmp v1.8.2. The main change with v1.8.0 is that the mining fee incurred by a liquidity purchase event triggered by a swap-in must be split between the two payments ([lest it's counted twice](https://github.com/ACINQ/lightning-kmp/pull/709)).

There are [side effects](https://github.com/ACINQ/lightning-kmp/pull/710) on other splice operations, which means we have a new `localMiningFees` field to store in the database.

To store this data in a backward compatible way, we do not store the local fee directly. Instead, we store the full mining fee (as before), and we retrieve the local fee by subtracting the purchase fee from the full fee.