### PR TITLE
Support fee bumping for on-chain transactions

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/cli/PhoenixCli.kt
@@ -65,7 +65,8 @@ fun main(args: Array<String>) =
             LnurlWithdraw(),
             LnurlAuth(),
             SendToAddress(),
-            CloseChannel()
+            BumpFee(),
+            CloseChannel(),
         )
         .main(args)
 
@@ -384,6 +385,18 @@ class SendToAddress : PhoenixCliCommand(name = "sendtoaddress", help = "Send to 
             formParameters = parameters {
                 append("amountSat", amountSat.toString())
                 append("address", address)
+                append("feerateSatByte", feerateSatByte.toString())
+            }
+        )
+    }
+}
+
+class BumpFee : PhoenixCliCommand(name = "bumpfee", help = "Bump the fee of an outgoing on-chain transaction", printHelpOnEmptyArgs = true) {
+    private val feerateSatByte by option("--feerateSatByte").int().required()
+    override suspend fun httpRequest() = commonOptions.httpClient.use {
+        it.submitForm(
+            url = (commonOptions.baseUrl / "bumpfee").toString(),
+            formParameters = parameters {
                 append("feerateSatByte", feerateSatByte.toString())
             }
         )


### PR DESCRIPTION
Usage:
```
$ ./phoenix-cli bumpfee --feerateSatByte 11
758b3df67c62c9cd9ebbde1ff6eaadc1c51f94d5b1a3efb2548236b9a6f1c659
```

Also, make `closechannel` return the `txid` upon success. All api calls producing a new on-chain transaction now return the `txid`:
- `sendtoaddress`
- `bumpfee`
- `closechannel`