### PR TITLE
Fix build on Linux arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is written in [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatfor
 
 ## Build
 
-### Native Linux/WSL
+### Native Linux/WSL x64
 
 Requires `libsqlite-dev` and `libcurl4-gnutls-dev`, both compiled against `glibc 2.19`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,6 @@ val buildVersionsTask by tasks.registering(Sync::class) {
 
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 val arch = System.getProperty("os.arch")
-println("architecture=$arch")
 
 kotlin {
     jvm {
@@ -202,7 +201,7 @@ distributions {
             }
         }
     }
-    if (currentOs.isLinux) {
+    if (currentOs.isLinux && arch != "aarch64") {
         create("linuxX64") {
             configureNativeDistribution("linuxX64Binaries", "linuxX64", "linux-x64")
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ val buildVersionsTask by tasks.registering(Sync::class) {
 
 val currentOs = org.gradle.internal.os.OperatingSystem.current()
 val arch = System.getProperty("os.arch")
+println("architecture=$arch")
 
 kotlin {
     jvm {


### PR DESCRIPTION
A regression was caused by #114, because we attempted to create packaging tasks that depend on native tasks, but those are not available on the Linux arm64 platform.

Fixes #120.