### PR TITLE
Upgrade to lightning-kmp 1.8.3

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     val kotlin = "1.9.23"
-    val lightningKmp = "1.8.2"
+    val lightningKmp = "1.8.3-SNAPSHOT"
     val sqlDelight = "2.0.1"
     val okio = "3.8.0"
     val clikt = "4.2.2"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     val kotlin = "1.9.23"
-    val lightningKmp = "1.8.3-SNAPSHOT"
+    val lightningKmp = "1.8.3"
     val sqlDelight = "2.0.1"
     val okio = "3.8.0"
     val clikt = "4.2.2"

--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/Api.kt
@@ -193,8 +193,8 @@ class Api(
                         description == null && descriptionHash != null -> Either.Right(descriptionHash)
                         else -> badRequest("Must provide either a description or descriptionHash")
                     }
-                    val expirySeconds = formParameters.getOptionalLong("expirySeconds")
-                    val invoice = peer.createInvoice(randomBytes32(), amount?.toMilliSatoshi(), eitherDesc, expirySeconds)
+                    val expiry = formParameters.getOptionalLong("expirySeconds")?.seconds
+                    val invoice = peer.createInvoice(randomBytes32(), amount?.toMilliSatoshi(), eitherDesc, expiry)
                     val externalId = formParameters["externalId"]
                     val webhookUrl = formParameters.getOptionalUrl("webhookUrl")
                     if (externalId != null || webhookUrl != null) {


### PR DESCRIPTION
It mostly includes cltv fixes for on-the-fly funding https://github.com/ACINQ/lightning-kmp/pull/714.

Also, the default invoice expiry for both bolt11/bolt12 invoices is now 24 hours.