### PR TITLE
Fix amount calculation for liquidity purchases in csv export

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/lightning/bin/csv/WalletPaymentCsvWriter.kt
+++ b/src/commonMain/kotlin/fr/acinq/lightning/bin/csv/WalletPaymentCsvWriter.kt
@@ -113,7 +113,7 @@ class WalletPaymentCsvWriter(path: Path) : CsvWriter(path) {
             is InboundLiquidityOutgoingPayment -> listOf(
                 Details(
                     Type.liquidity_purchase,
-                    amount = 0.msat,
+                    amount = -payment.feePaidFromChannelBalance.total.toMilliSatoshi(),
                     feeCredit = -payment.feeCreditUsed,
                     miningFee = payment.miningFees,
                     serviceFee = payment.serviceFees.toMilliSatoshi(),


### PR DESCRIPTION
Depending on the `payment_type`, fees for a liquidity purchase may be paid from the balance, or from future htlcs. In the former case, the fee amount must be deducted from the balance immediately.

A helper method `InboundLiquidityOutgoingPayment.feePaidFromChannelBalance` has been introduced for that purpose in
https://github.com/ACINQ/lightning-kmp/pull/706 and we must use it.