### PR TITLE
dev: add a docker image to compile for devs

### DIFF
--- a/.docker/Dockerfile.dev
+++ b/.docker/Dockerfile.dev
@@ -1,0 +1,49 @@
+# Use Ubuntu image for building for compatibility with macOS arm64 builds
+FROM eclipse-temurin:21-jdk-jammy AS BUILD
+
+# Set necessary args and environment variables for building phoenixd
+ARG LIGHTNING_KMP_BRANCH=macros/offer-with-description
+
+# Upgrade all packages and install dependencies
+RUN apt-get update \
+    && apt-get upgrade -y
+RUN apt-get install -y --no-install-recommends bash git \
+    && apt clean
+
+# Build dependencies in case the work require a lightning-kmp version
+#WORKDIR /lightning-kmp
+#RUN git clone --recursive --branch ${LIGHTNING_KMP_BRANCH} \
+#    https://github.com/vincenzopalazzo/lightning-kmp . \
+#    && ./gradlew publishToMavenLocal -x dokkaHtml
+
+# Git pull phoenixd source at specified tag/branch and compile phoenixd
+WORKDIR /phoenixd
+COPY . /phoenixd
+RUN  ./gradlew distTar
+
+# Alpine image to minimize final image size
+FROM eclipse-temurin:21-jre-alpine as FINAL
+
+# Upgrade all packages and install dependencies
+RUN apk update \
+    && apk upgrade --no-interactive
+RUN apk add --update --no-cache bash
+
+# Create a phoenix group and user
+RUN addgroup -S phoenix -g 1000 \
+    && adduser -S phoenix -G phoenix -u 1000 -h /phoenix
+USER phoenix
+
+# Unpack the release
+WORKDIR /phoenix
+COPY --chown=phoenix:phoenix --from=BUILD /phoenixd/build/distributions/phoenix-*-jvm.tar .
+RUN tar --strip-components=1 -xvf phoenix-*-jvm.tar
+
+# Indicate that the container listens on port 9740
+EXPOSE 9740
+
+# Expose default data directory as VOLUME
+VOLUME [ "/phoenix" ]
+
+# Run the daemon
+ENTRYPOINT ["/phoenix/bin/phoenixd", "--agree-to-terms-of-service", "--http-bind-ip", "0.0.0.0", "--http-password", "test", "--chain", "testnet"]


### PR DESCRIPTION
To build, move to the .docker dir and run `docker build  -f Dockerfile.dev -t phoenixd-dev ../` and then run the image with `docker run -p 9740:9740 phoenixd-dev`

for context, the repository does not build on archlinux (glibc problem) and I am still get the JVM panic in nix https://github.com/ACINQ/phoenixd/pull/12

So this adds a customized version of the Dockerfile for dev in order to be able to test custom code