### PR TITLE
Add an api call to get an outgoing ln payment by hash

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
@@ -260,9 +260,9 @@ class Api(
                         ?.let { call.respond(it) }
                         ?: call.respond(HttpStatusCode.NotFound)
                 }
-                get("payments/outgoingbyhash") {
+                get("payments/outgoingbyhash/{paymentHash}") {
                     val paymentHash = call.parameters.getByteVector32("paymentHash")
-                    val payment = paymentDb.listLightningOutgoingPayments(paymentHash).maxByOrNull {
+                    val payment: ApiType? = paymentDb.listLightningOutgoingPayments(paymentHash).maxByOrNull {
                         when (it.status) {
                             is LightningOutgoingPayment.Status.Succeeded -> 3
                             is LightningOutgoingPayment.Status.Pending -> 2

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
@@ -260,6 +260,19 @@ class Api(
                         ?.let { call.respond(it) }
                         ?: call.respond(HttpStatusCode.NotFound)
                 }
+                get("payments/outgoingbyhash") {
+                    val paymentHash = call.parameters.getByteVector32("paymentHash")
+                    val payment = paymentDb.listLightningOutgoingPayments(paymentHash).maxByOrNull {
+                        when (it.status) {
+                            is LightningOutgoingPayment.Status.Succeeded -> 3
+                            is LightningOutgoingPayment.Status.Pending -> 2
+                            is LightningOutgoingPayment.Status.Failed -> 1
+                        }
+                    }
+                    payment
+                        ?.let { call.respond(ApiType.OutgoingPayment(it)) }
+                        ?: call.respond(HttpStatusCode.NotFound)
+                }
                 authenticate("full-access", strategy = AuthenticationStrategy.Required) {
                     post("payinvoice") {
                         val formParameters = call.receiveParameters()


### PR DESCRIPTION
Since there may be several attempts, we return the first successful one if any, or else the first pending if any, or else the first failed payment.

Usage:
```bash
curl -X GET 'http://localhost:9740/payments/outgoingbyhash?paymentHash=<paymentHash>'
     -u :<password>
```