### PR TITLE
Upgrade to Kotlin 2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 build/
 .cxx
+.kotlin
 
 # this file is local to the dev environment and must not be pushed!
 local.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,11 @@ kotlin {
         // there is no kotlin native toolchain for linux arm64 yet, but we can still build for the JVM
         // see https://youtrack.jetbrains.com/issue/KT-51794/Cant-run-JVM-targets-on-ARM-Linux-when-using-Kotlin-Multiplatform-plugin
         linuxX64 {
+            compilations["main"].cinterops.create("sqlite") {
+                // use sqlite3 amalgamation on linux tests to prevent linking issues on new linux distros with dependency libraries which are to recent (for example glibc)
+                // see: https://github.com/touchlab/SQLiter/pull/38#issuecomment-867171789
+                definitionFile.set(File("$rootDir/src/nativeInterop/cinterop/sqlite3.def"))
+            }
             phoenixBinaries()
         }
     }
@@ -207,6 +212,8 @@ tasks.withType<KotlinNativeTest> {
 }
 
 sqldelight {
+    // On Linux we build libsqlite locally using cinterops
+    linkSqlite = !currentOs.isLinux
     databases {
         create("PhoenixDatabase") {
             packageName.set("fr.acinq.phoenixd.db.sqldelight")

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,4 @@ kotlin.incremental.multiplatform=true
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.ignoreDisabledTargets=true
+kotlin.native.cacheKind.linuxX64=none

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
-kotlin = "1.9.23"
-okio = "3.8.0"
-clikt = "4.2.2"
-ktor = "2.3.8"
-sqldelight = "2.0.1" # TODO: remove 'addEnclosingTransaction' hack in AfterVersionX files when upgrading
+kotlin = "2.1.0"
+okio = "3.10.2"
+clikt = "4.4.0"
+ktor = "2.3.12"
+sqldelight = "2.0.2" # TODO: remove 'addEnclosingTransaction' hack in AfterVersionX files when upgrading
 lightningkmp = "1.8.5-SNAPSHOT"
 
 # test dependencies
-test-logback = "1.2.3"
+test-logback = "1.5.16"
 
 [plugins]
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
@@ -37,7 +37,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.util.*
-import io.ktor.utils.io.core.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/json/JsonSerializers.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/json/JsonSerializers.kt
@@ -41,6 +41,7 @@ import kotlinx.serialization.UseSerializers
 sealed class ApiType {
 
     @Serializable
+    @ConsistentCopyVisibility
     data class Channel internal constructor(
         val state: String,
         val channelId: ByteVector32? = null,

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/payments/PayDnsAddress.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/payments/PayDnsAddress.kt
@@ -16,8 +16,8 @@ class PayDnsAddress {
         HttpClient {
             install(ContentNegotiation) {
                 json(json = Json { ignoreUnknownKeys = true })
-                expectSuccess = false
             }
+            expectSuccess = false
         }
     }
 

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/payments/lnurl/LnurlHandler.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/payments/lnurl/LnurlHandler.kt
@@ -42,8 +42,8 @@ class LnurlHandler(
         HttpClient {
             install(ContentNegotiation) {
                 json(json = Json { ignoreUnknownKeys = true })
-                expectSuccess = false
             }
+            expectSuccess = false
         }
     }
 


### PR DESCRIPTION
Also update a few dependencies.

There is an incompatibility between multiplatform and java plugins, but it's just a warning for now. The suggested fix is to create a module for the java app, but it seems [the issue is addressed in 2.1.20](https://kotlinlang.org/docs/whatsnew-eap.html#kotlin-multiplatform-new-dsl-to-replace-gradle-s-application-plugin). Let's do nothing for now.

We are now building sqlite with `cinterop` using a trick found in sqldelight. It gets rids of linking issues on linux x64, because there is no mismatch anymore of glibc versions. We previously had to build the project on an old `Ubuntu 18`. @sstone the missing thing was `kotlin.native.cacheKind.linuxX64=none` for the magic to work.