### PR TITLE
Remove requirement for `libsqlite`/`libcurl` in building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ It is written in [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatfor
 
 ### Requirements
 
-For all platforms:
-
 - [OpenJDK 21](https://adoptium.net/temurin/releases/?package=jdk&version=21)
 
 ### Native Linux/WSL x64

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ It is written in [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatfor
 
 ### Native Linux/WSL x64
 
-Requires `libsqlite-dev` and `libcurl4-gnutls-dev`, both compiled against `glibc 2.19`.
-
 ```shell
 ./gradlew linuxX64DistZip
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ It is written in [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatfor
 
 ## Build
 
+### Requirements
+
+For all platforms:
+
+- [OpenJDK 21](https://adoptium.net/temurin/releases/?package=jdk&version=21)
+
 ### Native Linux/WSL x64
 
 ```shell


### PR DESCRIPTION
They are not required anymore since #145 and #147.