### PR TITLE
Add optional `--paymentHash` arg to `getoutgoingpayment`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
@@ -114,6 +114,11 @@ class Api(
             status(HttpStatusCode.NotFound) { call, status ->
                 call.respondText(text = "Unknown endpoint (check api doc)", status = status)
             }
+            status(HttpStatusCode.NoContent) { call, _ ->
+                // Will be returned when a payment lookup returns no result for a given id.
+                // We convert those to 404 for backward compatibility, and because it is more correct for a REST interface.
+                call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
+            }
         }
         install(Authentication) {
             basic {
@@ -236,7 +241,7 @@ class Api(
                     }
                     payment
                         ?.let { call.respond(it) }
-                        ?: call.respond(HttpStatusCode.NotFound)
+                        ?: call.respond(HttpStatusCode.NoContent)
                 }
                 get("payments/outgoing") {
                     val payments: List<ApiType> = paymentDb.listOutgoingPayments(
@@ -258,7 +263,7 @@ class Api(
                     val payment: ApiType? = paymentDb.getLightningOutgoingPayment(uuid)?.let { ApiType.OutgoingPayment(it) }
                     payment
                         ?.let { call.respond(it) }
-                        ?: call.respond(HttpStatusCode.NotFound)
+                        ?: call.respond(HttpStatusCode.NoContent)
                 }
                 get("payments/outgoingbyhash/{paymentHash}") {
                     val paymentHash = call.parameters.getByteVector32("paymentHash")
@@ -273,7 +278,7 @@ class Api(
                         ?.let { ApiType.OutgoingPayment(it) }
                     payment
                         ?.let { call.respond(it) }
-                        ?: call.respond(HttpStatusCode.NotFound)
+                        ?: call.respond(HttpStatusCode.NoContent)
                 }
                 authenticate("full-access", strategy = AuthenticationStrategy.Required) {
                     post("payinvoice") {


### PR DESCRIPTION
Follow-up to #144.

Usage:
```bash
$ ./phoenix-cli getoutgoingpayment --paymentHash 8243eff932613faf8b7d6df3255f245e14ad680549d5bbe4cbb89340647adc46
{
    "type": "outgoing_payment",
    "subType": "lightning",
    "paymentId": "a3f5c209-08ef-4d26-9f53-c7bcee83a53a",
    "paymentHash": "8243eff932613faf8b7d6df3255f245e14ad680549d5bbe4cbb89340647adc46",
    "preimage": "27feae48fb63923dafc9661b20aba176be72268e395b1fcfc4893b445778902d",
    "isPaid": true,
    "sent": 1242,
    "fees": 8936,
    "completedAt": 1740501021144,
    "createdAt": 1740501020566
}
```
Note that `--uuid` and `--paymentHash` are exclusive:
```
$ ./phoenix-cli getoutgoingpayment --uuid a3f5c209-08ef-4d26-9f53-c7bcee83a53a --paymentHash 8243eff932613faf8b7d6df3255f245e14ad680549d5bbe4cbb89340647adc46
Usage: phoenix-cli getoutgoingpayment [<options>]

Error: option --uuid cannot be used with --paymentHash
```