### PR TITLE
Upgrade to lightning-kmp 1.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlinx-io = "0.6.0"
 clikt = "4.4.0"
 ktor = "3.1.0"
 sqldelight = "2.0.2" # TODO: remove 'addEnclosingTransaction' hack in AfterVersionX files when upgrading
-lightningkmp = "1.8.5-SNAPSHOT"
+lightningkmp = "1.9.0"
 kermit-io = "2.0.5"
 
 # test dependencies


### PR DESCRIPTION
This version includes https://github.com/ACINQ/lightning-kmp/pull/765 which should fix #118 and #136.