### PR TITLE
Optionally provide the seed path with `--seed-path`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Phoenixd.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Phoenixd.kt
@@ -111,7 +111,7 @@ class Phoenixd : CliktCommand() {
             "50k" to 50_000.sat,
             "100k" to 100_000.sat,
         ).convert { it.toMilliSatoshi() }.default(100_000.sat.toMilliSatoshi(), "100k")
-        private val maxRelativeFeePct by option("--max-relative-fee-percent", help = "Max relative fee for on-chain operations in percent.", hidden = true)
+        private val maxRelativeFeePct by option("--max-relative-fee-percent", help = "Max relative fee for on-chain operations in percent", hidden = true)
             .int()
             .restrictTo(1..50)
             .default(30)
@@ -177,10 +177,10 @@ class Phoenixd : CliktCommand() {
             .convert { SeedSpec.SeedPath(Path(it)) }
     ).single().default(SeedSpec.SeedPath(Path(datadir, "seed.dat")))
 
-    private val logRotateSize by option("--log-rotate-size", help = "Log rotate size in MB.")
+    private val logRotateSize by option("--log-rotate-size", help = "Log rotate size in MB")
         .long().convert { it * 1024 * 1024 }
         .default(10 * 1024 * 1024, "10")
-    private val logRotateMaxFiles by option("--log-rotate-max-files", help = "Maximum number of log files kept.")
+    private val logRotateMaxFiles by option("--log-rotate-max-files", help = "Maximum number of log files kept")
         .int()
         .default(5, "5")
 

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/conf/Seed.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/conf/Seed.kt
@@ -1,9 +1,11 @@
 package fr.acinq.phoenixd.conf
 
+import com.github.ajalt.clikt.core.UsageError
 import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.MnemonicCode
 import fr.acinq.lightning.Lightning.randomBytes
 import fr.acinq.lightning.utils.toByteVector
+import fr.acinq.phoenixd.Phoenixd
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
@@ -15,18 +17,21 @@ data class PhoenixSeed(val seed: ByteVector, val isNew: Boolean, val path: Path?
 /**
  * @return a pair with the seed and a boolean indicating whether the seed was newly generated
  */
-fun getOrGenerateSeed(dir: Path): PhoenixSeed {
-    val file = Path(dir, "seed.dat")
-    val (mnemonics, isNew) = if (SystemFileSystem.exists(file)) {
-        val contents = SystemFileSystem.source(file).buffered().use { it.readString() }
-        val mnemonics = Regex("[a-z]+").findAll(contents).map { it.value }.toList()
-        mnemonics to false
-    } else {
-        val entropy = randomBytes(16)
-        val mnemonics = MnemonicCode.toMnemonics(entropy)
-        SystemFileSystem.sink(file).buffered().use { it.writeString(mnemonics.joinToString(" ")) }
-        mnemonics to true
+fun Phoenixd.SeedSpec.SeedPath.getOrGenerateSeed(): PhoenixSeed {
+    try {
+        val (mnemonics, isNew) = if (SystemFileSystem.exists(path)) {
+            val contents = SystemFileSystem.source(path).buffered().use { it.readString() }
+            val mnemonics = Regex("[a-z]+").findAll(contents).map { it.value }.toList()
+            mnemonics to false
+        } else {
+            val entropy = randomBytes(16)
+            val mnemonics = MnemonicCode.toMnemonics(entropy)
+            SystemFileSystem.sink(path).buffered().use { it.writeString(mnemonics.joinToString(" ")) }
+            mnemonics to true
+        }
+        MnemonicCode.validate(mnemonics)
+        return PhoenixSeed(seed = MnemonicCode.toSeed(mnemonics, "").toByteVector(), isNew = isNew, path = path)
+    } catch (t: Throwable) {
+        throw UsageError(t.message, paramName = "seed")
     }
-    MnemonicCode.validate(mnemonics)
-    return PhoenixSeed(seed = MnemonicCode.toSeed(mnemonics, "").toByteVector(), isNew = isNew, path = file)
 }


### PR DESCRIPTION
In addition to `--seed` (which allows explicitly providing the 12 words seed), there is now a `--seed-path` argument to set an alternative path for the seed file. The two options are mutually exclusive.

Usage:
```bash
$ ./phoenixd --seed-path /run/secrets/phoenix_seed.dat
```

Fixes #135.