### PR TITLE
Add support for linux arm64 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # phoenixd
 
 **phoenixd** is the server equivalent of the popular [phoenix wallet](https://github.com/ACINQ/phoenix) for mobile.
-It is written in [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html) and runs natively on Linux, MacOS (x86 and ARM), and Windows (WSL).
+It is written in [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html) and runs natively on Linux (x86 and ARM), MacOS (x86 and ARM), and Windows (WSL).
 
 ## Build
 
@@ -18,6 +18,12 @@ It is written in [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatfor
 
 ```shell
 ./gradlew linuxX64DistZip
+```
+
+### Native Linux arm64
+
+```shell
+./gradlew linuxArm64DistZip
 ```
 
 ### Native MacOS x64

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.ignoreDisabledTargets=true
 kotlin.native.cacheKind.linuxX64=none
+kotlin.native.cacheKind.linuxArm64=none

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
+        mavenLocal()
         maven("https://oss.sonatype.org/content/repositories/snapshots")
         mavenCentral()
         google()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,13 +1,11 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
     }
 }
 
 dependencyResolutionManagement {
     repositories {
-        mavenLocal()
         maven("https://oss.sonatype.org/content/repositories/snapshots")
         mavenCentral()
         google()


### PR DESCRIPTION
See https://github.com/ACINQ/secp256k1-kmp/pull/120 for limitations.
I checked that `phoenixd` starts correctly on an AWS arm64 machine (with AWS Linux 2023). 