### PR TITLE
Upgrade to Kotlin 2.1.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ project/target
 DeleteMe*.scala
 
 # unzipped jvm packages
-phoenix-*-jvm
+phoenixd-*-jvm

--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ It is written in [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatfor
 
 ### JVM
 ```shell
-./gradlew distZip
+./gradlew jvmDistZip
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.1.10-blue.svg?style=flat&logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.1.20-blue.svg?style=flat&logo=kotlin)](http://kotlinlang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![](https://img.shields.io/badge/www-Homepage-green.svg)](https://phoenix.acinq.co/server)
 [![](https://img.shields.io/badge/www-API_doc-red.svg)](https://phoenix.acinq.co/server/api)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,7 +173,7 @@ kotlin {
 
 distributions {
     fun Distribution.configureNativeDistribution(buildTask: String, dir: String, classifier: String) {
-        distributionBaseName = "phoenix"
+        distributionBaseName = "phoenixd"
         distributionClassifier = classifier
         contents {
             from(tasks[buildTask])

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithHostTests
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 import java.io.ByteArrayOutputStream
@@ -7,7 +9,7 @@ plugins {
     alias(libs.plugins.multiplatform)
     alias(libs.plugins.serialization)
     alias(libs.plugins.sqldelight)
-    application
+    distribution
 }
 
 /** Get the current git commit hash. */
@@ -51,7 +53,26 @@ val arch = System.getProperty("os.arch")
 
 kotlin {
     jvm {
-        withJava()
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        binaries {
+            // this distribution is only needed to generate eclair-cli scripts
+            executable(KotlinCompilation.MAIN_COMPILATION_NAME, "phoenix-cli") {
+                applicationName.set("phoenix-cli")
+                mainClass.set("fr.acinq.phoenixd.cli.PhoenixCliKt")
+            }
+            executable {
+                applicationName.set("phoenixd")
+                mainClass.set("fr.acinq.phoenixd.PhoenixdKt")
+                applicationDistribution
+                    .from("$projectDir/build/jvmPhoenix-cli/scripts") {
+                    include("*")
+                }.into("bin")
+            }
+            // generate the phoenix-cli scripts before building the main jvm ditribution
+            tasks["jvmDistZip"].dependsOn("startScriptsForJvmPhoenix-cli")
+            // hide the phoenix-cli distribution task from the 'tasks' output
+            tasks.filter { it.name.contains("Phoenix-cliDist") }.forEach { it.group = null }
+        }
     }
 
     fun KotlinNativeTargetWithHostTests.phoenixBinaries() {
@@ -148,26 +169,7 @@ kotlin {
     }
 }
 
-application {
-    mainClass = "fr.acinq.phoenixd.PhoenixdKt"
-}
-
-val cliScripts by tasks.register("cliScripts", CreateStartScripts::class) {
-    mainClass.set("fr.acinq.phoenixd.cli.PhoenixCliKt")
-    outputDir = tasks.startScripts.get().outputDir
-    classpath = tasks.startScripts.get().classpath
-    applicationName = "phoenix-cli"
-}
-
-tasks.startScripts {
-    dependsOn(cliScripts)
-}
-
 distributions {
-    main {
-        distributionBaseName = "phoenix"
-        distributionClassifier = "jvm"
-    }
     fun Distribution.configureNativeDistribution(buildTask: String, dir: String, classifier: String) {
         distributionBaseName = "phoenix"
         distributionClassifier = classifier

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,9 +147,11 @@ kotlin {
                 implementation("ch.qos.logback:logback-classic:${libs.versions.test.logback.get()}")
             }
         }
-        nativeMain {
-            dependencies {
-                implementation("app.cash.sqldelight:native-driver:${libs.versions.sqldelight.get()}")
+        if (currentOs.isLinux || currentOs.isMacOsX) {
+            nativeMain {
+                dependencies {
+                    implementation("app.cash.sqldelight:native-driver:${libs.versions.sqldelight.get()}")
+                }
             }
         }
         if (currentOs.isLinux) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.1.10"
+kotlin = "2.1.20"
 kotlinx-io = "0.6.0"
 clikt = "4.4.0"
 ktor = "3.1.0"

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/db/migrations/v4/queries/InboundLiquidityQueries.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/db/migrations/v4/queries/InboundLiquidityQueries.kt
@@ -59,8 +59,6 @@ object InboundLiquidityQueries {
                     is Bolt12IncomingPayment -> incomingPayment.copy(
                         liquidityPurchaseDetails = liquidityPurchaseDetails
                     ) to incomingPayment.completedAt
-
-                    else -> null to null
                 }
                 val liquidityPayment = AutomaticLiquidityPurchasePayment(
                     id = UUID.fromString(id),


### PR DESCRIPTION
This solves the gradle warning about `application` plugin.  See kotlin's [release note](https://kotlinlang.org/docs/whatsnew2120.html#kotlin-multiplatform-new-dsl-to-replace-gradle-s-application-plugin).

Changes:
- `./gradlew distZip` becomes `./gradlew jvmDistZip`
- packages are renamed from `phoenix-<version>-<platform>.zip` to `phoenixd-<version>-<platform>.zip`