### PR TITLE
Support stateless offers with optional custom description and amount

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
@@ -210,6 +210,9 @@ class Api(
                     val maxDescriptionSize = 128
                     val description = formParameters["description"]
                         ?.also { if (it.length > maxDescriptionSize) badRequest("Request parameter description is too long (max $maxDescriptionSize characters)") }
+                    if (amount != null && description == null) {
+                        badRequest("Must provide a description if an amount is specified")
+                    }
                     call.respond(nodeParams.randomOffer(peer.walletParams.trampolineNode.id, amount?.toMilliSatoshi(), description).first.encode())
                 }
                 get("getoffer") {

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
@@ -204,6 +204,14 @@ class Api(
                     }
                     call.respond(GeneratedInvoice(invoice.amount?.truncateToSatoshi(), invoice.paymentHash, serialized = invoice.write()))
                 }
+                post("createoffer") {
+                    val formParameters = call.receiveParameters()
+                    val amount = formParameters.getOptionalLong("amountSat")?.sat
+                    val maxDescriptionSize = 128
+                    val description = formParameters["description"]
+                        ?.also { if (it.length > maxDescriptionSize) badRequest("Request parameter description is too long (max $maxDescriptionSize characters)") }
+                    call.respond(nodeParams.randomOffer(peer.walletParams.trampolineNode.id, amount?.toMilliSatoshi(), description).first.encode())
+                }
                 get("getoffer") {
                     call.respond(nodeParams.defaultOffer(peer.walletParams.trampolineNode.id).first.encode())
                 }

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
@@ -54,6 +54,7 @@ fun main(args: Array<String>) =
             GetIncomingPayment(),
             ListIncomingPayments(),
             CreateInvoice(),
+            CreateOffer(),
             GetOffer(),
             GetLnAddress(),
             PayInvoice(),
@@ -246,7 +247,22 @@ class CreateInvoice : PhoenixCliCommand(name = "createinvoice", help = "Create a
     }
 }
 
-class GetOffer : PhoenixCliCommand(name = "getoffer", help = "Return a Lightning offer (static invoice)") {
+class CreateOffer : PhoenixCliCommand(name = "createoffer", help = "Create a Lightning offer (reusable invoice)") {
+    private val amountSat by option("--amountSat").long()
+    private val description by option("--description", "--desc")
+
+    override suspend fun httpRequest() = commonOptions.httpClient.use {
+        it.submitForm(
+            url = (commonOptions.baseUrl / "createoffer").toString(),
+            formParameters = parameters {
+                amountSat?.let { append("amountSat", it.toString()) }
+                description?.let { append("description", it) }
+            }
+        )
+    }
+}
+
+class GetOffer : PhoenixCliCommand(name = "getoffer", help = "Return a default Lightning offer (reusable invoice). Consider using 'createinvoice' instead.") {
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.get(url = commonOptions.baseUrl / "getoffer")
     }


### PR DESCRIPTION
This implements https://github.com/ACINQ/lightning-kmp/pull/774.

A new `createoffer` (similar to `createinvoice` but reusable) is added, with two optional args:
- `description`
- `amountSat`

Usage:
```
./phoenix-cli createoffer --description="my custom description"
``` 