### PR TITLE
Use native releases in the Docker image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -3,8 +3,8 @@ FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-jammy AS build
 
 # Set necessary args and environment variables for building phoenixd
 ARG TARGETPLATFORM
-ARG PHOENIXD_BRANCH=v0.5.1
-ARG PHOENIXD_COMMIT_HASH=ab9a026432a61d986d83c72df5619014414557be
+ARG PHOENIXD_BRANCH=v0.6.0
+ARG PHOENIXD_COMMIT_HASH=fa318d9cd600aff45df132b7c01cbb959e66caa4
 
 # Upgrade all packages and install dependencies
 RUN apt-get update \

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,7 +1,8 @@
 # Use Ubuntu image for building for compatibility with macOS arm64 builds
-FROM eclipse-temurin:21-jdk-jammy AS build
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-jammy AS build
 
 # Set necessary args and environment variables for building phoenixd
+ARG TARGETPLATFORM
 ARG PHOENIXD_BRANCH=v0.5.1
 ARG PHOENIXD_COMMIT_HASH=ab9a026432a61d986d83c72df5619014414557be
 
@@ -15,16 +16,22 @@ RUN apt-get install -y --no-install-recommends bash git \
 WORKDIR /phoenixd
 RUN git clone --recursive --single-branch --branch ${PHOENIXD_BRANCH} -c advice.detachedHead=false \
     https://github.com/ACINQ/phoenixd . \
-    && test `git rev-parse HEAD` = ${PHOENIXD_COMMIT_HASH} || exit 1 \
-    && ./gradlew jvmDistTar
+    && test `git rev-parse HEAD` = ${PHOENIXD_COMMIT_HASH} || exit 1
 
-# JRE image to minimize final image size
-FROM eclipse-temurin:21-jre-jammy AS final
+RUN case "${TARGETPLATFORM}" in \
+        "linux/amd64") ./gradlew linkPhoenixdReleaseExecutableLinuxX64 ;; \
+        "linux/arm64") ./gradlew linkPhoenixdReleaseExecutableLinuxArm64 ;; \
+        *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
+    esac
+
+# Slim image to minimize final image size (Alpine is smaller but not glibc-based)
+FROM debian:bookworm-slim AS final
 
 # Upgrade all packages and install dependencies
 RUN apt-get update \
-    && apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends bash
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends bash \
+    && apt clean
 
 # Create a phoenix group and user
 RUN addgroup --system phoenix --gid 1000 \
@@ -33,8 +40,7 @@ USER phoenix
 
 # Unpack the release
 WORKDIR /phoenix
-COPY --chown=phoenix:phoenix --from=build /phoenixd/build/distributions/phoenixd-*-jvm.tar .
-RUN tar --strip-components=1 -xvf phoenixd-*-jvm.tar
+COPY --chown=phoenix:phoenix --from=build /phoenixd/build/bin/*/phoenixdReleaseExecutable/phoenixd.kexe phoenixd
 
 # Indicate that the container listens on port 9740
 EXPOSE 9740
@@ -43,4 +49,4 @@ EXPOSE 9740
 VOLUME [ "/phoenix" ]
 
 # Run the daemon
-ENTRYPOINT ["/phoenix/bin/phoenixd", "--agree-to-terms-of-service", "--http-bind-ip", "0.0.0.0"]
+ENTRYPOINT ["/phoenix/phoenixd", "--agree-to-terms-of-service", "--http-bind-ip", "0.0.0.0"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -45,8 +45,10 @@ COPY --chown=phoenix:phoenix --from=build /phoenixd/build/bin/*/phoenixdReleaseE
 # Indicate that the container listens on port 9740
 EXPOSE 9740
 
+# Create the data directory so permissions are preserved when mounted as a volume (otherwise would be mounted as root)
+RUN mkdir -p /phoenix/.phoenix
 # Expose default data directory as VOLUME
-VOLUME [ "/phoenix" ]
+VOLUME [ "/phoenix/.phoenix" ]
 
 # Run the daemon
 ENTRYPOINT ["/phoenix/phoenixd", "--agree-to-terms-of-service", "--http-bind-ip", "0.0.0.0"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -19,8 +19,8 @@ RUN git clone --recursive --single-branch --branch ${PHOENIXD_BRANCH} -c advice.
     && test `git rev-parse HEAD` = ${PHOENIXD_COMMIT_HASH} || exit 1
 
 RUN case "${TARGETPLATFORM}" in \
-        "linux/amd64") ./gradlew linkPhoenixdReleaseExecutableLinuxX64 ;; \
-        "linux/arm64") ./gradlew linkPhoenixdReleaseExecutableLinuxArm64 ;; \
+        "linux/amd64") ./gradlew linkPhoenixdReleaseExecutableLinuxX64 linkPhoenix-cliReleaseExecutableLinuxX64 ;; \
+        "linux/arm64") ./gradlew linkPhoenixdReleaseExecutableLinuxArm64 linkPhoenix-cliReleaseExecutableLinuxArm64 ;; \
         *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
     esac
 
@@ -41,6 +41,7 @@ USER phoenix
 # Unpack the release
 WORKDIR /phoenix
 COPY --chown=phoenix:phoenix --from=build /phoenixd/build/bin/*/phoenixdReleaseExecutable/phoenixd.kexe phoenixd
+COPY --chown=phoenix:phoenix --from=build /phoenixd/build/bin/*/phoenix-cliReleaseExecutable/phoenix-cli.kexe phoenix-cli
 
 # Indicate that the container listens on port 9740
 EXPOSE 9740


### PR DESCRIPTION
This a follow-up to #161, specifically:
> The goal of using the JVM on docker was for compatibility with ARM. Once we support native ARM on Linux (https://github.com/ACINQ/phoenixd/pull/157), we could potentially move back to Alpine with native phoenixd, an even smaller footprint than before.

I didn't go with Alpine because it isn't glibc based and we could run into compat issues. Nevertheless, with Debian slim the image size has been reduced from 230MB to 40MB (-80%).

Cross-platform build:
```shell
docker buildx build --platform linux/amd64,linux/arm64 -t acinq/phoenixd:0.6.0 --push .docker
```

From now on the image will be published on docker hub: https://hub.docker.com/repository/docker/acinq/phoenixd/general.
