### PR TITLE
Make default value for `maxFeeCredit` depend on `autoLiquidity`

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Phoenixd.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Phoenixd.kt
@@ -109,13 +109,12 @@ class Phoenixd : CliktCommand() {
         val maxFeeCredit by option("--max-fee-credit", help = "Max fee credit, if reached payments will be rejected").choice(
             "off" to 0.sat,
             "50k" to 50_000.sat,
-            "100k" to 100_000.sat,
             "125k" to 125_000.sat,
             "250k" to 250_000.sat,
         )
             .convert { it.toMilliSatoshi() }
-            .defaultLazy("2.5% of auto-liquidity amount with a min of 100k sat") {
-                100_000.sat.max(autoLiquidity * 2.5 / 100).toMilliSatoshi()
+            .defaultLazy("2.5% of auto-liquidity amount") {
+                (autoLiquidity * 2.5 / 100).toMilliSatoshi()
             }
         private val maxRelativeFeePct by option("--max-relative-fee-percent", help = "Max relative fee for on-chain operations in percent", hidden = true)
             .int()


### PR DESCRIPTION
The fee credit must be significantly greater than the typical fee for the configured `auto-liquidity` amount, otherwise we will reject payments that could go through.

The reason is that liquidity fees depend on mining fees which are volatile, and may increase between the time when phoenix accepts otf liquidity, and the time when the LSP allocates the liquidity. We want phoenix to be able to afford the increase of cost, so we require the incoming payment + fee credit to greater than the estimated fee, with a security margin (that security margin used to be 2x the estimated fee, but has been reduced in https://github.com/ACINQ/lightning-kmp/pull/793).

But this creates another issue: if the max allowed fee credit is less than the minimal liquidity fee (which was the case with the fixed default of 100k, if the user sets `auto-liquidity=10m`), then we will end up rejecting an incoming payment that is comfortably above, but less than two times, the total liquidity fee, instead of adding the payment to the fee credit.