### PR TITLE
Upgrade to lightning-kmp 1.10.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlinx-io = "0.6.0"
 clikt = "4.4.0"
 ktor = "3.1.2"
 sqldelight = "2.1.0"
-lightningkmp = "1.10.2"
+lightningkmp = "1.10.4"
 kermit-io = "2.0.5"
 
 # test dependencies


### PR DESCRIPTION
Notably, this increases `maxAcceptedHtlcs` to 12 (https://github.com/ACINQ/lightning-kmp/pull/797).