### PR TITLE
Do not filter out events with negative amounts

### DIFF
--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Phoenixd.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Phoenixd.kt
@@ -317,7 +317,7 @@ class Phoenixd : CliktCommand() {
                     nodeParams.nodeEvents
                         .collect {
                             when {
-                                it is PaymentEvents.PaymentReceived && it.payment.amount > 0.msat -> {
+                                it is PaymentEvents.PaymentReceived -> {
                                     when (val payment = it.payment) {
                                         is LightningIncomingPayment -> {
                                             val metadata = paymentsDb.metadataQueries.get(payment.paymentHash)


### PR DESCRIPTION
Depending on liquidity settings, it may happen that a small incoming payment triggers a large purchase of inbound liquidity, paying from the current channel balance. In this scenario, the received amount for that particular payment will be negative, because the cost of the purchase is greater than the value of that payment. We should still emit the associated webhook/websocket event.