### PR TITLE
Enable optimized binaries in release mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,14 +83,17 @@ kotlin {
     }
 
     fun KotlinNativeTarget.phoenixBinaries() {
+        compilerOptions {
+            // without this, release mode throws 'Index 0 out of bounds for length 0' in StaticInitializersOptimization.kt
+            // due to the use of external serializers for sealed classes in lightning-kmp
+            freeCompilerArgs.add("-Xdisable-phases=RemoveRedundantCallsToStaticInitializersPhase")
+        }
         binaries {
             executable("phoenixd") {
                 entryPoint = "fr.acinq.phoenixd.main"
-                optimized = false // without this, release mode throws 'Index 0 out of bounds for length 0' in StaticInitializersOptimization.kt
             }
             executable("phoenix-cli") {
                 entryPoint = "fr.acinq.phoenixd.cli.main"
-                optimized = false // without this, release mode throws 'Index 0 out of bounds for length 0' in StaticInitializersOptimization.kt
             }
         }
     }


### PR DESCRIPTION
We had to explicitly disable the optimized mode due to an `'Index 0 out of bounds for length 0' in StaticInitializersOptimization.kt` error at compilation. This is caused by the use of external serializers for sealed classes in lightning-kmp, and it turns out we can simply skip this particular phase in the kotlin compiler optimization process.