### PR TITLE
Bump Ktor to 3.4.0 to fix SSL on linuxArm64

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.2.20"
 kotlinx-io = "0.8.0"
 clikt = "4.4.0"
-ktor = "3.3.0"
+ktor = "3.4.0"
 sqldelight = "2.1.0"
 lightningkmp = "1.11.4"
 kermit-io = "2.0.8"


### PR DESCRIPTION
## Problem

Ktor 3.3.0 ships a bundled libcurl for `linuxArm64` that has **no default CA certificate path** compiled in. This means every outgoing HTTPS request (e.g. webhook delivery) fails with:

```
peer certificate cannot be authenticated with given CA certificates
```

TLS verification fails because libcurl cannot locate system CA certificates on ARM64 Linux hosts.

This is tracked upstream as [KTOR-8339](https://youtrack.jetbrains.com/issue/KTOR-8339).

## Fix

Bump Ktor from 3.3.0 to 3.4.0, which includes the fix for KTOR-8339.

## Changes

- `gradle/libs.versions.toml`: `ktor = "3.3.0"` → `ktor = "3.4.0"`