### PR TITLE
Add a `sendAll` option for Lightning payments

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.3.10"
 kotlinx-io = "0.9.0"
-clikt = "4.4.0"
+clikt = "5.1.0"
 ktor = "3.4.1"
 sqldelight = "2.2.1"
 lightningkmp = "1.11.5"

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
@@ -7,6 +7,7 @@ import fr.acinq.bitcoin.utils.Either
 import fr.acinq.bitcoin.utils.Try
 import fr.acinq.bitcoin.utils.toEither
 import fr.acinq.lightning.Lightning.randomBytes32
+import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.PaymentEvents
 import fr.acinq.lightning.blockchain.fee.FeeratePerByte
@@ -295,7 +296,11 @@ class Api(
                 authenticate("full-access", strategy = AuthenticationStrategy.Required) {
                     post("payinvoice") {
                         val formParameters = call.receiveParameters()
-                        val overrideAmount = formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
+                        val overrideAmount = when {
+                            formParameters.contains("sendAll") && formParameters.contains("amountSat") -> error("cannot use both amountSat and sendAll request parameters")
+                            formParameters.contains("sendAll") -> 0.msat
+                            else -> formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
+                        }
                         val invoice = formParameters.getInvoice("invoice")
                         val amount = (overrideAmount ?: invoice.amount) ?: missing("amountSat")
                         when (val event = peer.payInvoice(amount, invoice)) {
@@ -306,7 +311,11 @@ class Api(
                     }
                     post("payoffer") {
                         val formParameters = call.receiveParameters()
-                        val overrideAmount = formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
+                        val overrideAmount = when {
+                            formParameters.contains("sendAll") && formParameters.contains("amountSat") -> error("cannot use both amountSat and sendAll request parameters")
+                            formParameters.contains("sendAll") -> 0.msat
+                            else -> formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
+                        }
                         val offer = formParameters.getOffer("offer")
                         val amount = (overrideAmount ?: offer.amount) ?: missing("amountSat")
                         val note = formParameters["message"]
@@ -318,7 +327,11 @@ class Api(
                     }
                     post("paylnaddress") {
                         val formParameters = call.receiveParameters()
-                        val amount = formParameters.getLong("amountSat").sat.toMilliSatoshi()
+                        val amount = when {
+                            formParameters.contains("sendAll") && formParameters.contains("amountSat") -> error("cannot use both amountSat and sendAll request parameters")
+                            formParameters.contains("sendAll") -> 0.msat
+                            else -> formParameters.getLong("amountSat").sat.toMilliSatoshi()
+                        }
                         val (username, domain) = formParameters.getEmailLikeAddress("address")
                         val note = formParameters["message"]
                         when (val res = addressResolver.resolveAddress(username, domain, amount, note)) {
@@ -359,7 +372,11 @@ class Api(
                 authenticate("full-access", strategy = AuthenticationStrategy.Required) {
                     post("lnurlpay") {
                         val formParameters = call.receiveParameters()
-                        val overrideAmount = formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
+                        val overrideAmount = when {
+                            formParameters.contains("sendAll") && formParameters.contains("amountSat") -> error("cannot use both amountSat and sendAll request parameters")
+                            formParameters.contains("sendAll") -> 0.msat
+                            else -> formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
+                        }
                         val comment = formParameters["message"]
                         val request = formParameters.getLnurl("lnurl")
                         // early abort to avoid executing an invalid url

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Api.kt
@@ -1,25 +1,20 @@
 package fr.acinq.phoenixd
 
 import fr.acinq.bitcoin.*
-import fr.acinq.bitcoin.crypto.Digest
-import fr.acinq.bitcoin.crypto.hmac
 import fr.acinq.bitcoin.utils.Either
 import fr.acinq.bitcoin.utils.Try
 import fr.acinq.bitcoin.utils.toEither
 import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.NodeParams
-import fr.acinq.lightning.PaymentEvents
 import fr.acinq.lightning.blockchain.fee.FeeratePerByte
 import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.channel.ChannelCloseResponse
-import fr.acinq.lightning.channel.ChannelCommand
 import fr.acinq.lightning.channel.ChannelFundingResponse
 import fr.acinq.lightning.channel.states.*
 import fr.acinq.lightning.crypto.LocalKeyManager
 import fr.acinq.lightning.db.*
 import fr.acinq.lightning.io.Peer
-import fr.acinq.lightning.io.WrappedChannelCommand
 import fr.acinq.lightning.logging.LoggerFactory
 import fr.acinq.lightning.logging.info
 import fr.acinq.lightning.logging.warning
@@ -56,12 +51,9 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
-import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.io.files.Path
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration.Companion.seconds
 
@@ -296,11 +288,7 @@ class Api(
                 authenticate("full-access", strategy = AuthenticationStrategy.Required) {
                     post("payinvoice") {
                         val formParameters = call.receiveParameters()
-                        val overrideAmount = when {
-                            formParameters.contains("sendAll") && formParameters.contains("amountSat") -> error("cannot use both amountSat and sendAll request parameters")
-                            formParameters.contains("sendAll") -> 0.msat
-                            else -> formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
-                        }
+                        val overrideAmount = formParameters.getOptionalAmount()
                         val invoice = formParameters.getInvoice("invoice")
                         val amount = (overrideAmount ?: invoice.amount) ?: missing("amountSat")
                         when (val event = peer.payInvoice(amount, invoice)) {
@@ -311,11 +299,7 @@ class Api(
                     }
                     post("payoffer") {
                         val formParameters = call.receiveParameters()
-                        val overrideAmount = when {
-                            formParameters.contains("sendAll") && formParameters.contains("amountSat") -> error("cannot use both amountSat and sendAll request parameters")
-                            formParameters.contains("sendAll") -> 0.msat
-                            else -> formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
-                        }
+                        val overrideAmount = formParameters.getOptionalAmount()
                         val offer = formParameters.getOffer("offer")
                         val amount = (overrideAmount ?: offer.amount) ?: missing("amountSat")
                         val note = formParameters["message"]
@@ -327,11 +311,7 @@ class Api(
                     }
                     post("paylnaddress") {
                         val formParameters = call.receiveParameters()
-                        val amount = when {
-                            formParameters.contains("sendAll") && formParameters.contains("amountSat") -> error("cannot use both amountSat and sendAll request parameters")
-                            formParameters.contains("sendAll") -> 0.msat
-                            else -> formParameters.getLong("amountSat").sat.toMilliSatoshi()
-                        }
+                        val amount = formParameters.getOptionalAmount() ?: missing("amountSat")
                         val (username, domain) = formParameters.getEmailLikeAddress("address")
                         val note = formParameters["message"]
                         when (val res = addressResolver.resolveAddress(username, domain, amount, note)) {
@@ -372,11 +352,7 @@ class Api(
                 authenticate("full-access", strategy = AuthenticationStrategy.Required) {
                     post("lnurlpay") {
                         val formParameters = call.receiveParameters()
-                        val overrideAmount = when {
-                            formParameters.contains("sendAll") && formParameters.contains("amountSat") -> error("cannot use both amountSat and sendAll request parameters")
-                            formParameters.contains("sendAll") -> 0.msat
-                            else -> formParameters["amountSat"]?.let { it.toLongOrNull() ?: invalidType("amountSat", "integer") }?.sat?.toMilliSatoshi()
-                        }
+                        val overrideAmount = formParameters.getOptionalAmount()
                         val comment = formParameters["message"]
                         val request = formParameters.getLnurl("lnurl")
                         // early abort to avoid executing an invalid url
@@ -593,5 +569,12 @@ class Api(
     private fun Parameters.getLnurlAuth(argName: String): LnurlAuth = this[argName]?.let { LnurlParser.extractLnurl(it) as LnurlAuth } ?: missing(argName)
 
     private fun Parameters.getOptionalUrl(argName: String): Url? = this[argName]?.let { runCatching { Url(it) }.getOrNull() ?: invalidType(argName, "url") }
+
+    private fun Parameters.getOptionalAmount(): MilliSatoshi? =
+        when {
+            this.contains("sendAll") && this.contains("amountSat") -> badRequest("Cannot use both amountSat and sendAll request parameters")
+            this.contains("sendAll") -> peer.maxSendableOverLightning()
+            else -> getOptionalLong("amountSat")?.sat?.toMilliSatoshi()
+        }
 
 }

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/Phoenixd.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/Phoenixd.kt
@@ -7,6 +7,7 @@ import co.touchlab.kermit.io.RollingFileLogWriter
 import co.touchlab.kermit.io.RollingFileLogWriterConfig
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context
+import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.output.MordantHelpFormatter
 import com.github.ajalt.clikt.parameters.groups.*
@@ -17,6 +18,7 @@ import com.github.ajalt.clikt.parameters.types.long
 import com.github.ajalt.clikt.parameters.types.restrictTo
 import com.github.ajalt.mordant.rendering.TextColors.*
 import com.github.ajalt.mordant.rendering.TextStyles.bold
+import com.github.ajalt.mordant.terminal.prompt
 import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.Chain
 import fr.acinq.bitcoin.MnemonicCode

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
@@ -1,12 +1,6 @@
 package fr.acinq.phoenixd.cli
 
-import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.Context
-import com.github.ajalt.clikt.core.context
-import com.github.ajalt.clikt.core.main
-import com.github.ajalt.clikt.core.obj
-import com.github.ajalt.clikt.core.requireObject
-import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.core.*
 import com.github.ajalt.clikt.output.MordantHelpFormatter
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.required
@@ -18,8 +12,10 @@ import com.github.ajalt.clikt.parameters.types.long
 import fr.acinq.bitcoin.Base58Check
 import fr.acinq.bitcoin.Bech32
 import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.bitcoin.Satoshi
 import fr.acinq.bitcoin.utils.Either
+import fr.acinq.lightning.payment.Bolt11Invoice
+import fr.acinq.lightning.utils.UUID
+import fr.acinq.lightning.wire.OfferTypes
 import fr.acinq.phoenixd.BuildVersions
 import fr.acinq.phoenixd.conf.ListValueSource
 import fr.acinq.phoenixd.conf.readConfFile
@@ -28,10 +24,6 @@ import fr.acinq.phoenixd.payments.Parser
 import fr.acinq.phoenixd.payments.lnurl.helpers.LnurlParser
 import fr.acinq.phoenixd.payments.lnurl.models.Lnurl
 import fr.acinq.phoenixd.payments.lnurl.models.LnurlAuth
-import fr.acinq.lightning.payment.Bolt11Invoice
-import fr.acinq.lightning.utils.UUID
-import fr.acinq.lightning.utils.sat
-import fr.acinq.lightning.wire.OfferTypes
 import io.ktor.client.*
 import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
@@ -78,11 +70,6 @@ fun main(args: Array<String>): kotlin.Unit =
         .main(args)
 
 data class HttpConf(val baseUrl: Url, val httpClient: HttpClient)
-
-sealed class AmountChoice {
-    data class Specific(val amountSat: Long) : AmountChoice()
-    object SendAll : AmountChoice()
-}
 
 class PhoenixCli : CliktCommand() {
     private val confFile = Path(datadir, "phoenix.conf")
@@ -287,19 +274,14 @@ class GetLnAddress : PhoenixCliCommand(name = "getlnaddress", help = "Return a B
 
 class PayInvoice : PhoenixCliCommand(name = "payinvoice", help = "Pay a Lightning invoice", printHelpOnEmptyArgs = true) {
     private val invoice by option("--invoice").required().check { Bolt11Invoice.read(it).isSuccess }
-    private val amountChoice by mutuallyExclusiveOptions(
-        option("--amountSat").long().convert { AmountChoice.Specific(it) },
-        option("--sendAll").nullableFlag().convert { AmountChoice.SendAll }.help("Send all available balance (incompatible with --amountSat)"),
-    )
+    private val amountSat by option("--amountSat").long()
+    private val sendAll by option("--sendAll").nullableFlag().help("Send all available balance (incompatible with --amountSat)")
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.submitForm(
             url = (commonOptions.baseUrl / "payinvoice").toString(),
             formParameters = parameters {
-                when(val value = amountChoice) {
-                    is AmountChoice.Specific -> append("amountSat", value.amountSat.toString())
-                    is AmountChoice.SendAll -> append("sendAdd", "true")
-                    else -> {}
-                }
+                amountSat?.let { append("amountSat", amountSat.toString()) }
+                sendAll?.let { append("sendAll", "true") }
                 append("invoice", invoice)
             }
         )
@@ -308,20 +290,15 @@ class PayInvoice : PhoenixCliCommand(name = "payinvoice", help = "Pay a Lightnin
 
 class PayOffer : PhoenixCliCommand(name = "payoffer", help = "Pay a Lightning offer", printHelpOnEmptyArgs = true) {
     private val offer by option("--offer").required().check { OfferTypes.Offer.decode(it).isSuccess }
-    private val amountChoice by mutuallyExclusiveOptions(
-        option("--amountSat").long().convert { AmountChoice.Specific(it) },
-        option("--sendAll").nullableFlag().convert { AmountChoice.SendAll }.help("Send all available balance (incompatible with --amountSat)"),
-    )
+    private val amountSat by option("--amountSat").long()
+    private val sendAll by option("--sendAll").nullableFlag().help("Send all available balance (incompatible with --amountSat)")
     private val message by option("--message").help { "Optional payer note" }
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.submitForm(
             url = (commonOptions.baseUrl / "payoffer").toString(),
             formParameters = parameters {
-                when (val value = amountChoice) {
-                    is AmountChoice.Specific -> append("amountSat", value.amountSat.toString())
-                    is AmountChoice.SendAll -> append("sendAdd", "true")
-                    else -> {}
-                }
+                amountSat?.let { append("amountSat", amountSat.toString()) }
+                sendAll?.let { append("sendAll", "true") }
                 append("offer", offer)
                 message?.let { append("message", message.toString()) }
             }
@@ -330,20 +307,17 @@ class PayOffer : PhoenixCliCommand(name = "payoffer", help = "Pay a Lightning of
 }
 
 class PayLnAddress : PhoenixCliCommand(name = "paylnaddress", help = "Pay a Lightning address (BIP353 or LNURL)", printHelpOnEmptyArgs = true) {
-    private val amountChoice by mutuallyExclusiveOptions(
-        option("--amountSat").long().convert { AmountChoice.Specific(it) },
-        option("--sendAll").nullableFlag().convert { AmountChoice.SendAll }.help("Send all available balance (incompatible with --amountSat)"),
-    ).required()
+    private val amountSat by option("--amountSat").long()
+    private val sendAll by option("--sendAll").nullableFlag().help("Send all available balance (incompatible with --amountSat)")
     private val address by option("--address").required().check { Parser.parseEmailLikeAddress(it) != null }
     private val message by option("--message").help { "Optional payer note" }
+
     override suspend fun httpRequest(): HttpResponse = commonOptions.httpClient.use {
         it.submitForm(
             url = (commonOptions.baseUrl / "paylnaddress").toString(),
             formParameters = parameters {
-                when (val value = amountChoice) {
-                    is AmountChoice.Specific -> append("amountSat", value.amountSat.toString())
-                    is AmountChoice.SendAll -> append("sendAdd", "true")
-                }
+                amountSat?.let { append("amountSat", amountSat.toString()) }
+                sendAll?.let { append("sendAll", "true") }
                 append("address", address)
                 message?.let { append("message", message.toString()) }
             }
@@ -376,10 +350,8 @@ class DecodeOffer : PhoenixCliCommand(name = "decodeoffer", help = "Decode a Lig
 }
 
 class LnurlPay : PhoenixCliCommand(name = "lnurlpay", help = "Pay a LNURL", printHelpOnEmptyArgs = true) {
-    private val amountChoice by mutuallyExclusiveOptions(
-        option("--amountSat").long().convert { AmountChoice.Specific(it) },
-        option("--sendAll").nullableFlag().convert { AmountChoice.SendAll }.help("Send all available balance (incompatible with --amountSat)"),
-    )
+    private val amountSat by option("--amountSat").long()
+    private val sendAll by option("--sendAll").nullableFlag().help("Send all available balance (incompatible with --amountSat)")
     private val lnurl by option("--lnurl").required()
         .check("not a valid lnurl-pay link") {
             val url = kotlin.runCatching { LnurlParser.extractLnurl(it) }.getOrNull()
@@ -390,11 +362,8 @@ class LnurlPay : PhoenixCliCommand(name = "lnurlpay", help = "Pay a LNURL", prin
         it.submitForm(
             url = (commonOptions.baseUrl / "lnurlpay").toString(),
             formParameters = parameters {
-                when (val value = amountChoice) {
-                    is AmountChoice.Specific -> append("amountSat", value.amountSat.toString())
-                    is AmountChoice.SendAll -> append("sendAdd", "true")
-                    else -> {}
-                }
+                amountSat?.let { append("amountSat", amountSat.toString()) }
+                sendAll?.let { append("sendAll", "true") }
                 append("lnurl", lnurl)
                 message?.let { append("message", message.toString()) }
             }

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
@@ -1,7 +1,10 @@
 package fr.acinq.phoenixd.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.context
+import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.core.obj
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.output.MordantHelpFormatter
@@ -43,7 +46,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
 import kotlinx.serialization.json.Json
 
-fun main(args: Array<String>) =
+fun main(args: Array<String>): kotlin.Unit =
     PhoenixCli()
         .versionOption(BuildVersions.phoenixdVersion, names = setOf("--version", "-v"))
         .subcommands(
@@ -123,7 +126,8 @@ class PhoenixCli : CliktCommand() {
     }
 }
 
-abstract class PhoenixCliCommand(val name: String, val help: String, printHelpOnEmptyArgs: Boolean = false) : CliktCommand(name = name, help = help, printHelpOnEmptyArgs = printHelpOnEmptyArgs) {
+abstract class PhoenixCliCommand(val name: String, val help: String, override val printHelpOnEmptyArgs: Boolean = false) : CliktCommand(name = name) {
+    override fun help(context: Context): String = help
     internal val commonOptions by requireObject<HttpConf>()
     abstract suspend fun httpRequest(): HttpResponse
     override fun run() {

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/cli/PhoenixCli.kt
@@ -15,6 +15,7 @@ import com.github.ajalt.clikt.parameters.types.long
 import fr.acinq.bitcoin.Base58Check
 import fr.acinq.bitcoin.Bech32
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Satoshi
 import fr.acinq.bitcoin.utils.Either
 import fr.acinq.phoenixd.BuildVersions
 import fr.acinq.phoenixd.conf.ListValueSource
@@ -26,6 +27,7 @@ import fr.acinq.phoenixd.payments.lnurl.models.Lnurl
 import fr.acinq.phoenixd.payments.lnurl.models.LnurlAuth
 import fr.acinq.lightning.payment.Bolt11Invoice
 import fr.acinq.lightning.utils.UUID
+import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.wire.OfferTypes
 import io.ktor.client.*
 import io.ktor.client.plugins.auth.*
@@ -73,6 +75,11 @@ fun main(args: Array<String>) =
         .main(args)
 
 data class HttpConf(val baseUrl: Url, val httpClient: HttpClient)
+
+sealed class AmountChoice {
+    data class Specific(val amountSat: Long) : AmountChoice()
+    object SendAll : AmountChoice()
+}
 
 class PhoenixCli : CliktCommand() {
     private val confFile = Path(datadir, "phoenix.conf")
@@ -275,13 +282,20 @@ class GetLnAddress : PhoenixCliCommand(name = "getlnaddress", help = "Return a B
 }
 
 class PayInvoice : PhoenixCliCommand(name = "payinvoice", help = "Pay a Lightning invoice", printHelpOnEmptyArgs = true) {
-    private val amountSat by option("--amountSat").long()
     private val invoice by option("--invoice").required().check { Bolt11Invoice.read(it).isSuccess }
+    private val amountChoice by mutuallyExclusiveOptions(
+        option("--amountSat").long().convert { AmountChoice.Specific(it) },
+        option("--sendAll").nullableFlag().convert { AmountChoice.SendAll }.help("Send all available balance (incompatible with --amountSat)"),
+    )
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.submitForm(
             url = (commonOptions.baseUrl / "payinvoice").toString(),
             formParameters = parameters {
-                amountSat?.let { append("amountSat", amountSat.toString()) }
+                when(val value = amountChoice) {
+                    is AmountChoice.Specific -> append("amountSat", value.amountSat.toString())
+                    is AmountChoice.SendAll -> append("sendAdd", "true")
+                    else -> {}
+                }
                 append("invoice", invoice)
             }
         )
@@ -289,14 +303,21 @@ class PayInvoice : PhoenixCliCommand(name = "payinvoice", help = "Pay a Lightnin
 }
 
 class PayOffer : PhoenixCliCommand(name = "payoffer", help = "Pay a Lightning offer", printHelpOnEmptyArgs = true) {
-    private val amountSat by option("--amountSat").long()
     private val offer by option("--offer").required().check { OfferTypes.Offer.decode(it).isSuccess }
+    private val amountChoice by mutuallyExclusiveOptions(
+        option("--amountSat").long().convert { AmountChoice.Specific(it) },
+        option("--sendAll").nullableFlag().convert { AmountChoice.SendAll }.help("Send all available balance (incompatible with --amountSat)"),
+    )
     private val message by option("--message").help { "Optional payer note" }
     override suspend fun httpRequest() = commonOptions.httpClient.use {
         it.submitForm(
             url = (commonOptions.baseUrl / "payoffer").toString(),
             formParameters = parameters {
-                amountSat?.let { append("amountSat", amountSat.toString()) }
+                when (val value = amountChoice) {
+                    is AmountChoice.Specific -> append("amountSat", value.amountSat.toString())
+                    is AmountChoice.SendAll -> append("sendAdd", "true")
+                    else -> {}
+                }
                 append("offer", offer)
                 message?.let { append("message", message.toString()) }
             }
@@ -305,14 +326,20 @@ class PayOffer : PhoenixCliCommand(name = "payoffer", help = "Pay a Lightning of
 }
 
 class PayLnAddress : PhoenixCliCommand(name = "paylnaddress", help = "Pay a Lightning address (BIP353 or LNURL)", printHelpOnEmptyArgs = true) {
-    private val amountSat by option("--amountSat").long().required()
+    private val amountChoice by mutuallyExclusiveOptions(
+        option("--amountSat").long().convert { AmountChoice.Specific(it) },
+        option("--sendAll").nullableFlag().convert { AmountChoice.SendAll }.help("Send all available balance (incompatible with --amountSat)"),
+    ).required()
     private val address by option("--address").required().check { Parser.parseEmailLikeAddress(it) != null }
     private val message by option("--message").help { "Optional payer note" }
     override suspend fun httpRequest(): HttpResponse = commonOptions.httpClient.use {
         it.submitForm(
             url = (commonOptions.baseUrl / "paylnaddress").toString(),
             formParameters = parameters {
-                append("amountSat", amountSat.toString())
+                when (val value = amountChoice) {
+                    is AmountChoice.Specific -> append("amountSat", value.amountSat.toString())
+                    is AmountChoice.SendAll -> append("sendAdd", "true")
+                }
                 append("address", address)
                 message?.let { append("message", message.toString()) }
             }
@@ -345,7 +372,10 @@ class DecodeOffer : PhoenixCliCommand(name = "decodeoffer", help = "Decode a Lig
 }
 
 class LnurlPay : PhoenixCliCommand(name = "lnurlpay", help = "Pay a LNURL", printHelpOnEmptyArgs = true) {
-    private val amountSat by option("--amountSat").long()
+    private val amountChoice by mutuallyExclusiveOptions(
+        option("--amountSat").long().convert { AmountChoice.Specific(it) },
+        option("--sendAll").nullableFlag().convert { AmountChoice.SendAll }.help("Send all available balance (incompatible with --amountSat)"),
+    )
     private val lnurl by option("--lnurl").required()
         .check("not a valid lnurl-pay link") {
             val url = kotlin.runCatching { LnurlParser.extractLnurl(it) }.getOrNull()
@@ -356,7 +386,11 @@ class LnurlPay : PhoenixCliCommand(name = "lnurlpay", help = "Pay a LNURL", prin
         it.submitForm(
             url = (commonOptions.baseUrl / "lnurlpay").toString(),
             formParameters = parameters {
-                amountSat?.let { append("amountSat", amountSat.toString()) }
+                when (val value = amountChoice) {
+                    is AmountChoice.Specific -> append("amountSat", value.amountSat.toString())
+                    is AmountChoice.SendAll -> append("sendAdd", "true")
+                    else -> {}
+                }
                 append("lnurl", lnurl)
                 message?.let { append("message", message.toString()) }
             }


### PR DESCRIPTION
A new `--sendAll` option is available for:
- `payinvoice`
- `payoffer`
- `paylnaddress`
- `lnurlpay`

It is mutually exclusive with `--amountSat`.

Example:
```
./phoenix-cli paylnaddress --address=starblocks@acinq.co --sendAll
```

It is best effort and will only empty the wallet if there is a single channel, which should normally be the case.

Also upgraded clikt.

Fixes #217.