### PR TITLE
Upgrade lightning-kmp to 1.12.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlinx-io = "0.9.0"
 clikt = "5.1.0"
 ktor = "3.4.1"
 sqldelight = "2.2.1"
-lightningkmp = "1.11.5"
+lightningkmp = "1.12.0"
 kermit-io = "2.0.8"
 
 # test dependencies

--- a/src/commonMain/kotlin/fr/acinq/phoenixd/payments/lnurl/helpers/LnurlAuthSigner.kt
+++ b/src/commonMain/kotlin/fr/acinq/phoenixd/payments/lnurl/helpers/LnurlAuthSigner.kt
@@ -5,6 +5,7 @@ import fr.acinq.bitcoin.crypto.Digest
 import fr.acinq.bitcoin.crypto.Pack
 import fr.acinq.bitcoin.crypto.hmac
 import fr.acinq.lightning.crypto.LocalKeyManager
+import fr.acinq.secp256k1.Secp256k1
 import io.ktor.http.*
 
 object LnurlAuthSigner {
@@ -14,7 +15,7 @@ object LnurlAuthSigner {
         challenge: String,
         key: PrivateKey
     ): Pair<PublicKey, ByteVector> {
-        return key.publicKey() to Crypto.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(challenge), privateKey = key))
+        return key.publicKey() to Secp256k1.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(challenge), privateKey = key).toByteArray()).byteVector()
     }
 
     /**


### PR DESCRIPTION
Changelog: https://github.com/ACINQ/lightning-kmp/compare/v1.11.5...v1.12.0.

Main change: use the official splice protocol.